### PR TITLE
use consistent country code from config model in callback payment req…

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -285,7 +285,7 @@ define([
                                         totalPriceStatus: 'FINAL',
                                         totalPrice: totals.base_grand_total.toString(),
                                         totalPriceLabel: 'Total',
-                                        countryCode: data.shippingAddress.countryCode
+                                        countryCode: configModel().getConfig().countryCode
                                     }
                                 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes unexpected developer error when the customers' address is from a different country to the configured "Default Country" for the store. 
When Google Pay is initialised we have to provide the countryCode as part of GooglePays "PaymentRequest", countryCode is optional but required for EAA countries. We use the stores' Default Country, but in our `onPaymentDataChanged` callback function we resolve it by returning a new updated "PaymentRequest: object like below:

```
...
{
    newShippingOptionParameters: {
        defaultSelectedOptionId: ...,
        shippingOptions: [{...}]
    },
    newTransactionInfo: {
        displayItems: [
            {
                label: 'Shipping',
                type: 'LINE_ITEM',
                price: xx,
                status: 'FINAL'
            }
        ],
            currencyCode: ...,
            totalPriceStatus: 'FINAL',
            totalPrice: xx,
            totalPriceLabel: 'Total',
            countryCode: ...
    }
...
```

The countryCode in the `newTransactionInfo` object here was being set from the customers shipping address rather than the stores countryCode, and hence we were getting the error reported around the initial paymentRequest having a different countryCode to the callback paymentRequest object. I've updated this callback country code so that it uses the same countryCode used when initialising (from the configModel) 

The countryCode should be (taken from Google Pays docs):

> The ISO 3166-1 alpha-2 country code where the transaction is processed. This property is required for merchants who process transactions in European Economic Area (EEA) countries and any other countries that are subject to [Strong Customer Authentication](https://developers.google.com/pay/api/web/guides/resources/sca) (SCA). Merchants must specify the acquirer bank country code.

So I'd say it makes sense to use the stores' country for the countryCode and this update making it consistent fixes the error reported because we use a consistent countryCode in the PaymentRequest throughout the Google Pay flow.

## Tested scenarios
<!-- Description of tested scenarios -->
- Google Pay guest/customer transactions from PDP/Minicart using a GooglePay shipping address with a different country to the stores configured default country - all worked as expected
- Regular E2E tests of ApplePay/GooglePay on PDP, Cart, Minicart


**Fixed issue**: Unexpected Developer Error when using GooglePay as a Customer with a different shipping address country than the stores' configured "Default Country"
