### PR TITLE
[PW-7613] set txVariant in shipping info

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -65,8 +65,7 @@ define([
                 googlePayAllowed: null,
                 isProductView: false,
                 maskedId: null,
-                googlePayComponent: null,
-                googlePayTxVariant: null
+                googlePayComponent: null
             },
 
             initialize: async function (config, element) {
@@ -326,7 +325,7 @@ define([
                             paymentMethod: {
                                 googlePayCardNetwork: paymentData.paymentMethodData.info.cardNetwork,
                                 googlePayToken: paymentData.paymentMethodData.tokenizationData.token,
-                                type: self.googlePayTxVariant.type
+                                type: self.googlePayComponent.props.type
                             }
                         }),
                          payload = {
@@ -336,7 +335,7 @@ define([
                             paymentMethod: {
                                 method: 'adyen_hpp',
                                 additional_data: {
-                                    brand_code: self.googlePayTxVariant.type,
+                                    brand_code: self.googlePayComponent.props.type,
                                     stateData
                                 },
                                 extension_attributes: getExtensionAttributes(paymentData)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
googlePayTxVariant isn’t set anymore, it was removed in a previous update so now googlePayTxVariant is always null and it doesn’t have a property of type.
Fix:
Use the `type` from the `googlePayComponent` when setting shipping information.

## Tested scenarios
<!-- Description of tested scenarios -->
Pay successfully with express checkout


