### PR TITLE
[PW-7999] Fix quote totals for PDP express initialisation

### DIFF
--- a/Model/ExpressInit.php
+++ b/Model/ExpressInit.php
@@ -189,6 +189,13 @@ class ExpressInit implements ExpressInitInterface
             );
             // We have to save it here to get the totals in the express data builder
             $this->quoteRepository->save($adyenExpressQuote);
+
+            // Quote object is required to collect the totals instead of cart object.
+            $quoteModel = $this->quoteRepository->getActive($adyenExpressQuote->getId());
+            $quoteModel->collectTotals();
+            $quoteModel->setTotalsCollectedFlag(false);
+            $this->quoteRepository->save($quoteModel);
+
             $expressData = $this->expressDataBuilder->execute(
                 $adyenExpressQuote,
                 $product
@@ -234,8 +241,7 @@ class ExpressInit implements ExpressInitInterface
             $product,
             $productCartParams
         );
-        $adyenExpressQuote->collectTotals();
-        $adyenExpressQuote->setTotalsCollectedFlag(false);
+
         return $adyenExpressQuote;
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Fix the usage of the `collectTotals()` method for the quote created in product detail page. Missing quote totals causes `amount/value` not being added to the `/paymentMethods` call request and Apple Pay tx_variant doesn't return in the payment methods in this case.

## Tested scenarios
<!-- Description of tested scenarios -->
- Apple Pay express from product detail page and minicart.