### PR TITLE
[PW-8234] Add missing browserInfo to the payment request

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -422,12 +422,7 @@ define([
                     }
                 };
 
-                const stateData = {
-                    'paymentMethod': {
-                        'type': 'applepay',
-                        'applePayToken': btoa(JSON.stringify(event.payment.token.paymentData))
-                    }
-                };
+                let componentData = self.applePayComponent.data;
 
                 setShippingInformation(payload, this.isProductView).done(function () {
                     // Submit payment information
@@ -437,7 +432,7 @@ define([
                             method: 'adyen_hpp',
                             additional_data: {
                                 brand_code: 'applepay',
-                                stateData: JSON.stringify(stateData)
+                                stateData: JSON.stringify(componentData)
                             }
                         }
                     };

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -331,17 +331,11 @@ define([
 
             startPlaceOrder: function (paymentData) {
                 let self = this;
+                let componentData = self.googlePayComponent.data;
 
                 this.setShippingInformation(paymentData)
                     .done(function () {
-                        const stateData = JSON.stringify({
-                            paymentMethod: {
-                                googlePayCardNetwork: paymentData.paymentMethodData.info.cardNetwork,
-                                googlePayToken: paymentData.paymentMethodData.tokenizationData.token,
-                                type: self.googlePayComponent.props.type
-                            }
-                        }),
-                         payload = {
+                        const payload = {
                             email: paymentData.email,
                             shippingAddress: this.mapAddress(paymentData.shippingAddress),
                             billingAddress: this.mapAddress(paymentData.paymentMethodData.info.billingAddress),
@@ -349,7 +343,7 @@ define([
                                 method: 'adyen_hpp',
                                 additional_data: {
                                     brand_code: self.googlePayComponent.props.type,
-                                    stateData
+                                    stateData: JSON.stringify(componentData)
                                 },
                                 extension_attributes: getExtensionAttributes(paymentData)
                             }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Instead of building the `stateData` manually on the frontend, web component's state data added to the `payment-information` payload.

## Tested scenarios
<!-- Description of tested scenarios -->
- GooglePay

Fixes #22 
