### PR TITLE
[PW-8356] - Add RC-V9 Support GooglePay

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -391,7 +391,6 @@ define([
             },
 
 
-
             setShippingInformation: function (paymentData) {
                 const shippingMethod = this.shippingMethods.find(function (method) {
                     return method.method_code === paymentData.shippingOptionData.id;

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -359,9 +359,6 @@ define([
                             shippingAddress: this.mapAddress(paymentData.shippingAddress),
                             billingAddress: this.mapAddress(paymentData.paymentMethodData.info.billingAddress),
                             paymentMethod: {
-                                /*/
-                                This is where we should change the method for updated method renderer.
-                                 */
                                 method: 'adyen_googlepay',
                                 additional_data: {
                                     brand_code: self.googlePayComponent.props.type,

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -340,7 +340,10 @@ define([
                             shippingAddress: this.mapAddress(paymentData.shippingAddress),
                             billingAddress: this.mapAddress(paymentData.paymentMethodData.info.billingAddress),
                             paymentMethod: {
-                                method: 'adyen_hpp',
+                                /*/
+                                This is where we should change the method for updated method renderer.
+                                 */
+                                method: 'adyen_googlepay',
                                 additional_data: {
                                     brand_code: self.googlePayComponent.props.type,
                                     stateData: JSON.stringify(componentData)
@@ -362,6 +365,8 @@ define([
                             });
                     }.bind(this));
             },
+
+
 
             setShippingInformation: function (paymentData) {
                 const shippingMethod = this.shippingMethods.find(function (method) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

Due to the separate JS files we need to update the adyen_hpp to adyen_googlepay for these payment methods for RC-V9. 

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change?  Supporting RC-V9 for googlepay
- What existing problem does this pull request solve?  Unable to do express checkout on RC-V9 without this. 
-->

## Tested scenarios
<!-- Description of tested scenarios -->

Tested express checkout including tokenization. 


**Fixed issue**:  <!-- #-prefixed issue number -->
