### PR TITLE
[PW-8640] Modify payment method code of Apple Pay request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "adyen/module-payment": "^8"
+    "adyen/module-payment": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "adyen/module-payment": "^*"
+    "adyen/module-payment": "^8"
   },
   "require-dev": {
     "phpunit/phpunit": "*",

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -429,7 +429,7 @@ define([
                     const postData = {
                         email: shippingContact.emailAddress,
                         paymentMethod: {
-                            method: 'adyen_hpp',
+                            method: 'adyen_applepay',
                             additional_data: {
                                 brand_code: 'applepay',
                                 stateData: JSON.stringify(componentData)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After migrating to separate payment methods, version 9 of the payment plugin doesn't have `adyen_hpp` payment method. Correct payment method code of Apple Pay request was updated with this PR.

## Tested scenarios
<!-- Description of tested scenarios -->
- Apple Pay exress payment