### PR TITLE
Add Apple Pay button color option

### DIFF
--- a/Block/ApplePay/Shortcut/Button.php
+++ b/Block/ApplePay/Shortcut/Button.php
@@ -22,7 +22,6 @@ use Magento\Catalog\Block\ShortcutInterface;
 use Magento\Checkout\Model\DefaultConfigProvider;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template\Context;
@@ -65,17 +64,17 @@ class Button extends AbstractButton implements ShortcutInterface
     /**
      * Button Constructor
      *
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Magento\Checkout\Model\Session $checkoutSession
-     * @param \Magento\Payment\Model\MethodInterface $payment
-     * @param \Magento\Framework\UrlInterface $url
-     * @param \Magento\Customer\Model\Session $customerSession
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
-     * @param \Magento\Checkout\Model\DefaultConfigProvider $defaultConfigProvider
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Adyen\Payment\Helper\Config $adyenConfigHelper
-     * @param \Adyen\ExpressCheckout\Model\ConfigurationInterface $configuration
+     * @param Context $context
+     * @param Session $checkoutSession
+     * @param MethodInterface $payment
+     * @param UrlInterface $url
+     * @param CustomerSession $customerSession
+     * @param StoreManagerInterface $storeManagerInterface
+     * @param DefaultConfigProvider $defaultConfigProvider
+     * @param ScopeConfigInterface $scopeConfig
+     * @param AdyenHelper $adyenHelper
+     * @param AdyenConfigHelper $adyenConfigHelper
+     * @param ConfigurationInterface $configuration
      * @param array $data
      */
     public function __construct(

--- a/Block/ApplePay/Shortcut/Button.php
+++ b/Block/ApplePay/Shortcut/Button.php
@@ -58,19 +58,24 @@ class Button extends AbstractButton implements ShortcutInterface
     private $scopeConfig;
 
     /**
-     * Button constructor
+     * @var ConfigurationInterface $configuration
+     */
+    private $configuration;
+
+    /**
+     * Button Constructor
      *
-     * @param Context $context
-     * @param Session $checkoutSession
-     * @param MethodInterface $payment
-     * @param UrlInterface $url
-     * @param CustomerSession $customerSession
-     * @param StoreManagerInterface $storeManagerInterface
-     * @param DefaultConfigProvider $defaultConfigProvider
-     * @param ScopeConfigInterface $scopeConfig
-     * @param AdyenHelper $adyenHelper
-     * @param ConfigurationInterface $configuration
-     * @param AdyenConfigHelper $adyenConfigHelper
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Payment\Model\MethodInterface $payment
+     * @param \Magento\Framework\UrlInterface $url
+     * @param \Magento\Customer\Model\Session $customerSession
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
+     * @param \Magento\Checkout\Model\DefaultConfigProvider $defaultConfigProvider
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Helper\Config $adyenConfigHelper
+     * @param \Adyen\ExpressCheckout\Model\ConfigurationInterface $configuration
      * @param array $data
      */
     public function __construct(
@@ -84,6 +89,7 @@ class Button extends AbstractButton implements ShortcutInterface
         ScopeConfigInterface $scopeConfig,
         AdyenHelper $adyenHelper,
         AdyenConfigHelper $adyenConfigHelper,
+        ConfigurationInterface $configuration,
         array $data = []
     ) {
         parent::__construct(
@@ -99,6 +105,7 @@ class Button extends AbstractButton implements ShortcutInterface
             $data
         );
         $this->defaultConfigProvider = $defaultConfigProvider;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -121,5 +128,13 @@ class Button extends AbstractButton implements ShortcutInterface
             }
         }
         return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getButtonColor(): string
+    {
+        return $this->configuration->getApplePayButtonColor();
     }
 }

--- a/Model/Config/Source/ApplePay/ButtonColor.php
+++ b/Model/Config/Source/ApplePay/ButtonColor.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model\Config\Source\ApplePay;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * @see https://docs.adyen.com/payment-methods/apple-pay/web-component/#ap-button-configuration
+ */
+class ButtonColor implements OptionSourceInterface
+{
+    public const BLACK = 'black';
+    public const WHITE = 'white';
+    public const WHITE_WITH_LINE = 'white-with-line';
+
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => self::BLACK,
+                'label' => 'Black button',
+            ],
+            [
+                'value' => self::WHITE,
+                'label' => 'White button with no outline',
+            ],
+            [
+                'value' => self::WHITE_WITH_LINE,
+                'label' => 'White button with black outline',
+            ],
+        ];
+    }
+}

--- a/Model/Config/Source/ShortcutAreas.php
+++ b/Model/Config/Source/ShortcutAreas.php
@@ -22,9 +22,7 @@ class ShortcutAreas implements OptionSourceInterface
     public const MINICART_VALUE = 3;
 
     /**
-     * Return array of options for Source Model
-     *
-     * @return array[]
+     * @inheritDoc
      */
     public function toOptionArray()
     {

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Model;
 
+use Adyen\ExpressCheckout\Model\Config\Source\ApplePay\ButtonColor;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 
@@ -55,6 +56,22 @@ class Configuration implements ConfigurationInterface
                 ',',
                 $value
             ) : [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getApplePayButtonColor(
+        string $scopeType = ScopeInterface::SCOPE_STORE,
+        $scopeCode = null
+    ): string {
+        $value = $this->scopeConfig->getValue(
+            self::APPLE_PAY_BUTTON_COLOR_CONFIG_PATH,
+            $scopeType,
+            $scopeCode
+        );
+
+        return $value ?: ButtonColor::BLACK;
     }
 
     /**

--- a/Model/ConfigurationInterface.php
+++ b/Model/ConfigurationInterface.php
@@ -24,6 +24,7 @@ interface ConfigurationInterface
 {
     public const SHOW_APPLE_PAY_ON_CONFIG_PATH = 'payment/adyen_hpp/show_apple_pay_on';
     public const SHOW_GOOGLE_PAY_ON_CONFIG_PATH = 'payment/adyen_hpp/show_google_pay_on';
+    public const APPLE_PAY_BUTTON_COLOR_CONFIG_PATH = 'payment/adyen_hpp/apple_pay_button_color';
 
     /**
      * Returns configuration value for where to show apple pay
@@ -36,6 +37,18 @@ interface ConfigurationInterface
         string $scopeType = ScopeInterface::SCOPE_STORE,
         $scopeCode = null
     ): array;
+
+    /**
+     * Returns Apple Pay button color, if no value set, black is returned
+     *
+     * @param string $scopeType
+     * @param $scopeCode
+     * @return string
+     */
+    public function getApplePayButtonColor(
+        string $scopeType = ScopeInterface::SCOPE_STORE,
+        $scopeCode = null
+    ): string;
 
     /**
      * Returns configuration value for where to show google pay

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -15,18 +15,32 @@
         <group id="adyen_hpp_express" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="200">
             <label>Express Payments</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-            <field id="show_google_pay_on" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Show GooglePay on</label>
-                <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
-                <can_be_empty>1</can_be_empty>
-                <config_path>payment/adyen_hpp/show_google_pay_on</config_path>
-            </field>
-            <field id="show_apple_pay_on" translate="label" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Show ApplePay on</label>
-                <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
-                <can_be_empty>1</can_be_empty>
-                <config_path>payment/adyen_hpp/show_apple_pay_on</config_path>
-            </field>
+            <group id="google_pay" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="10">
+                <label>GooglePay</label>
+                <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+                <field id="show_google_pay_on" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Show on</label>
+                    <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
+                    <can_be_empty>1</can_be_empty>
+                    <config_path>payment/adyen_hpp/show_google_pay_on</config_path>
+                </field>
+            </group>
+            <group id="apple_pay" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
+                <label>Apple Pay</label>
+                <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+                <field id="show_apple_pay_on" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Show on</label>
+                    <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
+                    <can_be_empty>1</can_be_empty>
+                    <config_path>payment/adyen_hpp/show_apple_pay_on</config_path>
+                </field>
+                <field id="apple_pay_button_color" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Button color</label>
+                    <source_model>Adyen\ExpressCheckout\Model\Config\Source\ApplePay\ButtonColor</source_model>
+                    <config_path>payment/adyen_hpp/apple_pay_button_color</config_path>
+                    <comment><![CDATA[More details here: <a href="https://developer.apple.com/design/human-interface-guidelines/apple-pay#Button-styles" target="_blank">Apple Pay documentation</a>.]]></comment>
+                </field>
+            </group>
         </group>
     </group>
 </include>

--- a/view/frontend/templates/applepay/shortcut.phtml
+++ b/view/frontend/templates/applepay/shortcut.phtml
@@ -24,7 +24,8 @@ $config = [
         'locale' => $block->getLocale(),
         'originkey' => $block->getOriginKey(),
         'checkoutenv' => $block->getCheckoutEnvironment(),
-        'isProductView' => (bool) $block->getIsProductView()
+        'isProductView' => (bool) $block->getIsProductView(),
+        'buttonColor' => $block->getButtonColor(),
     ]
 ];
 ?>

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -209,7 +209,6 @@ define([
                     countryCode: countryCode,
                     currencyCode: currency,
                     totalPriceLabel: $t('Grand Total'),
-                    buttonColor: config.buttonColor ?? 'black',
                     configuration: {
                         domainName: window.location.hostname,
                         merchantId: applePaymentMethod.configuration.merchantId,

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -67,7 +67,7 @@ define([
                 shippingMethods: {},
                 isProductView: false,
                 maskedId: null,
-                applePayComponent: null
+                applePayComponent: null,
             },
 
             initialize: async function (config, element) {
@@ -209,6 +209,7 @@ define([
                     countryCode: countryCode,
                     currencyCode: currency,
                     totalPriceLabel: $t('Grand Total'),
+                    buttonColor: config.buttonColor ?? 'black',
                     configuration: {
                         domainName: window.location.hostname,
                         merchantId: applePaymentMethod.configuration.merchantId,

--- a/view/frontend/web/js/helpers/getApplePayStyles.js
+++ b/view/frontend/web/js/helpers/getApplePayStyles.js
@@ -1,11 +1,13 @@
-define(function () {
+define([
+    'Adyen_ExpressCheckout/js/model/config',
+], function (config) {
     'use strict';
 
     return function () {
         // Default styles that can be overridden by themes.
         return {
             buttonType: 'plain',
-            buttonColor: 'black'
+            buttonColor: config?.buttonColor ?? 'black'
         };
     };
 });

--- a/view/frontend/web/js/helpers/getApplePayStyles.js
+++ b/view/frontend/web/js/helpers/getApplePayStyles.js
@@ -1,9 +1,11 @@
 define([
     'Adyen_ExpressCheckout/js/model/config',
-], function (config) {
+], function (configModel) {
     'use strict';
 
     return function () {
+        const config = configModel().getConfig();
+
         // Default styles that can be overridden by themes.
         return {
             buttonType: 'plain',


### PR DESCRIPTION
## Summary

This PR adds the ability to choose the style of the Apple Pay button. In addition, the GooglePay and Apple Pay methods are separated into 2 different groups to improve configuration management.

![Capture d’écran du 2023-11-02 15-56-18](https://github.com/Adyen/adyen-magento2-express-checkout/assets/34821762/825ad5e7-0bd7-44d7-aad9-9021cb0c3ac9)
![Capture d’écran du 2023-11-02 15-56-28](https://github.com/Adyen/adyen-magento2-express-checkout/assets/34821762/bf8ea5f1-82bd-4b6b-b976-17811d4d97ca)

Issue: #50