### PR TITLE
[ECP-8666] Revisit Express Checkout configuration fields

### DIFF
--- a/Model/ConfigurationInterface.php
+++ b/Model/ConfigurationInterface.php
@@ -22,8 +22,8 @@ use Magento\Store\Model\ScopeInterface;
  */
 interface ConfigurationInterface
 {
-    public const SHOW_APPLE_PAY_ON_CONFIG_PATH = 'payment/adyen_hpp/show_apple_pay_on';
-    public const SHOW_GOOGLE_PAY_ON_CONFIG_PATH = 'payment/adyen_hpp/show_google_pay_on';
+    public const SHOW_APPLE_PAY_ON_CONFIG_PATH = 'payment/adyen_express/show_apple_pay_on';
+    public const SHOW_GOOGLE_PAY_ON_CONFIG_PATH = 'payment/adyen_express/show_google_pay_on';
 
     /**
      * Returns configuration value for where to show apple pay

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ bin/magento cache:clean
 
 ## Configuration Steps
 1. Add the payment method in your [Customer Area](https://docs.adyen.com/payment-methods#add-payment-methods-to-your-account).
-2. Make sure that Alternative payment methods are activated in your [Magento configuration](https://docs.adyen.com/plugins/magento-2/set-up-the-payment-methods-in-magento#alternative-payment-methods).
-3. In the Magento admin page, go to Alternative payment methods > Express Payments > Show Google Pay on > Select one or all of your desired options.
+2. Make sure that Payment methods are activated in your [Magento configuration](https://docs.adyen.com/plugins/adobe-commerce/set-up-the-payment-methods-in-adobe-commerce/).
+3. In the Magento admin page, go to Accepting Payments > Online Checkout > Express Payments > Show Google Pay on > Select one or all of your desired options.
 4. For Apple Pay: [Use Adyen's Apple Pay Certificate to go live](https://docs.adyen.com/payment-methods/apple-pay/web-component#going-live), without designing your Apple Pay integration.
 5. For Google Pay: Set up [Google Pay](https://docs.adyen.com/payment-methods/google-pay/web-component#before-you-go-live).
 

--- a/Setup/Patch/Data/UpdateExpressDBPaths.php
+++ b/Setup/Patch/Data/UpdateExpressDBPaths.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2023 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchVersionInterface;
+
+class UpdateExpressDBPaths implements DataPatchInterface, PatchVersionInterface
+{
+    private ModuleDataSetupInterface $moduleDataSetup;
+    private WriterInterface $configWriter;
+    private ReinitableConfigInterface $reinitableConfig;
+
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        WriterInterface $configWriter,
+        ReinitableConfigInterface $reinitableConfig
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->configWriter = $configWriter;
+        $this->reinitableConfig = $reinitableConfig;
+    }
+
+    public function apply(): void
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        // Update Apple Pay config path
+        $this->updateConfigValue(
+            $this->moduleDataSetup,
+            'payment/adyen_hpp/show_apple_pay_on',
+            'payment/adyen_express/show_apple_pay_on'
+        );
+
+        // Update Google Pay config path
+        $this->updateConfigValue(
+            $this->moduleDataSetup,
+            'payment/adyen_hpp/show_google_pay_on',
+            'payment/adyen_express/show_google_pay_on'
+        );
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+    }
+
+    private function updateConfigValue(
+        ModuleDataSetupInterface $setup,
+        string $oldPath,
+        string $newPath
+    ): void {
+        $config = $this->findConfig($setup, $oldPath);
+
+        if ($config !== false) {
+            $this->configWriter->save(
+                $newPath,
+                $config['value'],
+                $config['scope'],
+                $config['scope_id']
+            );
+        }
+
+        $this->reinitableConfig->reinit();
+    }
+
+    private function findConfig(ModuleDataSetupInterface $setup, string $path): mixed
+    {
+        $configDataTable = $setup->getTable('core_config_data');
+        $connection = $setup->getConnection();
+
+        $select = $connection->select()
+            ->from($configDataTable)
+            ->where(
+                'path = ?',
+                $path
+            );
+
+        $matchingConfigs = $connection->fetchAll($select);
+        return reset($matchingConfigs);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public static function getVersion(): string
+    {
+        return '2.0.0';
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,8 +14,8 @@
     <system>
         <section id="payment">
             <group id="adyen_group_all_in_one">
-                <group id="adyen_configure_payment_methods">
-                    <include path="Adyen_ExpressCheckout::system/adyen_hpp.xml"/>
+                <group id="adyen_accepting_payments">
+                    <include path="Adyen_ExpressCheckout::system/adyen_online_checkout.xml"/>
                 </group>
             </group>
         </section>

--- a/etc/adminhtml/system/adyen_online_checkout.xml
+++ b/etc/adminhtml/system/adyen_online_checkout.xml
@@ -11,21 +11,21 @@
  */
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
-    <group id="adyen_hpp">
-        <group id="adyen_hpp_express" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="200">
+    <group id="adyen_online_checkout">
+        <group id="adyen_express" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="50">
             <label>Express Payments</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
             <field id="show_google_pay_on" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Show GooglePay on</label>
                 <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
                 <can_be_empty>1</can_be_empty>
-                <config_path>payment/adyen_hpp/show_google_pay_on</config_path>
+                <config_path>payment/adyen_express/show_google_pay_on</config_path>
             </field>
             <field id="show_apple_pay_on" translate="label" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Show ApplePay on</label>
                 <source_model>Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas</source_model>
                 <can_be_empty>1</can_be_empty>
-                <config_path>payment/adyen_hpp/show_apple_pay_on</config_path>
+                <config_path>payment/adyen_express/show_apple_pay_on</config_path>
             </field>
         </group>
     </group>


### PR DESCRIPTION
## Summary
After changing the configuration page design on V9, the Express Modules' configuration fields are revisited with this PR

## Tested scenarios
- setup Express methods in the admin panel and test the payments

