### PR TITLE
Hide Apple Pay component by default and display it only if method is available

### DIFF
--- a/view/frontend/templates/applepay/shortcut.phtml
+++ b/view/frontend/templates/applepay/shortcut.phtml
@@ -28,6 +28,8 @@ $config = [
     ]
 ];
 ?>
-<div class="adyen-checkout__dropin apple-pay-button-card" id="<?= $id ?>"
+<div class="adyen-checkout__dropin apple-pay-button-card"
+     id="<?= $id ?>"
+     style="display: none"
      data-mage-init="<?= $escaper->escapeHtmlAttr(json_encode($config)) ?>">
 </div>

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -158,10 +158,15 @@ define([
                 this.applePayComponent
                     .isAvailable()
                     .then(() => {
+                        $(element).show();
                         this.applePayComponent.mount(element);
-                    }).catch(e => {
-                        console.log('Apple pay is unavailable.', e);
+                    }).catch((e) => {
+                        this.onNotAvailable(e);
                     });
+            },
+
+            onNotAvailable: function (error) {
+                console.log('Apple pay is unavailable.', error);
             },
 
             unmountApplePay: function () {


### PR DESCRIPTION
## Summary

Hide Apple Pay component by default and display it only if method is available. Avoids front-side edge effects if the component is not displayed.

I also add an `onNotAvailable` function to avoid having to copy the whole function in case of modification in a theme.

**Fixed issue**:  #54 
