### PR TITLE
Apple Pay - Display merchant name in Label

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -208,7 +208,7 @@ define([
                 return {
                     countryCode: countryCode,
                     currencyCode: currency,
-                    totalPriceLabel: $t('Grand Total'),
+                    totalPriceLabel: this.getMerchantName(),
                     configuration: {
                         domainName: window.location.hostname,
                         merchantId: applePaymentMethod.configuration.merchantId,
@@ -318,7 +318,7 @@ define([
 
                                 applePayShippingContactUpdate.newShippingMethods = shippingMethods;
                                 applePayShippingContactUpdate.newTotal = {
-                                    label: $t('Grand Total'),
+                                    label: this.getMerchantName(),
                                     amount: (response.grand_total + response.tax_amount).toString()
                                 };
                                 applePayShippingContactUpdate.newLineItems = [
@@ -387,7 +387,7 @@ define([
 
                         applePayShippingMethodUpdate.newTotal = {
                             type: 'final',
-                            label: $t('Grand Total'),
+                            label: this.getMerchantName(),
                             amount: (response.grand_total + response.tax_amount).toString()
                         };
                         applePayShippingMethodUpdate.newLineItems = [
@@ -503,7 +503,12 @@ define([
                     console.error('Adyen ApplePay Unable to set shipping information', e);
                     reject(window.ApplePaySession.STATUS_INVALID_BILLING_POSTAL_ADDRESS);
                 });
-            }
+            },
+
+            getMerchantName: function() {
+                const config = configModel().getConfig();
+                return config?.merchantAccount ?? $t('Grand Total');
+            },
         });
     }
 );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR changes the merchant name displayed in Apple Pay. By default it is the name of the merchant Adyen that is displayed, the user can easily change this value via a mixin.

![IMG_20231109_082806](https://github.com/Adyen/adyen-magento2-express-checkout/assets/34821762/57dbafd7-6826-437b-b59e-87cff4804690)




**Fixed issue**:  #57 
