### PR TITLE
Apple Pay - Replace fake billing phone by contact phone

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -454,7 +454,7 @@ define([
                         },
                         'billing_address': {
                             'email': shippingContact.emailAddress,
-                            'telephone': '0000000000',
+                            'telephone': shippingContact.phoneNumber,
                             'firstname': billingContact.givenName,
                             'lastname': billingContact.familyName,
                             'street': billingContact.addressLines,


### PR DESCRIPTION
## Summary

Replace fake billing phone (ie: `0000000000`) by contact phone for Apple Pay express checkout.

![IMG_20231113_151516](https://github.com/Adyen/adyen-magento2-express-checkout/assets/34821762/18e5a897-43c1-41b0-b799-ce1cbc3dce08)

**Fixed issue**:  #61