### PR TITLE
Checkout agreements

### DIFF
--- a/Block/ApplePay/Shortcut/Button.php
+++ b/Block/ApplePay/Shortcut/Button.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Block\ApplePay\Shortcut;
 
+use Adyen\ExpressCheckout\Model\AgreementsProvider;
 use Adyen\Payment\Helper\Data as AdyenHelper;
 use Adyen\Payment\Helper\Config as AdyenConfigHelper;
 use Adyen\ExpressCheckout\Block\Buttons\AbstractButton;
@@ -37,26 +38,6 @@ class Button extends AbstractButton implements ShortcutInterface
     private $defaultConfigProvider;
 
     /**
-     * @var UrlInterface $url
-     */
-    private $url;
-
-    /**
-     * @var CustomerSession $customerSession
-     */
-    private $customerSession;
-
-    /**
-     * @var StoreManagerInterface $storeManager
-     */
-    private $storeManager;
-
-    /**
-     * @var ScopeConfigInterface $scopeConfig
-     */
-    private $scopeConfig;
-
-    /**
      * @var ConfigurationInterface $configuration
      */
     private $configuration;
@@ -64,17 +45,18 @@ class Button extends AbstractButton implements ShortcutInterface
     /**
      * Button Constructor
      *
-     * @param Context $context
-     * @param Session $checkoutSession
-     * @param MethodInterface $payment
-     * @param UrlInterface $url
-     * @param CustomerSession $customerSession
-     * @param StoreManagerInterface $storeManagerInterface
-     * @param DefaultConfigProvider $defaultConfigProvider
-     * @param ScopeConfigInterface $scopeConfig
-     * @param AdyenHelper $adyenHelper
-     * @param AdyenConfigHelper $adyenConfigHelper
-     * @param ConfigurationInterface $configuration
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Payment\Model\MethodInterface $payment
+     * @param \Magento\Framework\UrlInterface $url
+     * @param \Magento\Customer\Model\Session $customerSession
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
+     * @param \Magento\Checkout\Model\DefaultConfigProvider $defaultConfigProvider
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Helper\Config $adyenConfigHelper
+     * @param \Adyen\ExpressCheckout\Model\ConfigurationInterface $configuration
+     * @param \Adyen\ExpressCheckout\Model\AgreementsProvider $agreementsProvider
      * @param array $data
      */
     public function __construct(
@@ -89,6 +71,7 @@ class Button extends AbstractButton implements ShortcutInterface
         AdyenHelper $adyenHelper,
         AdyenConfigHelper $adyenConfigHelper,
         ConfigurationInterface $configuration,
+        AgreementsProvider $agreementsProvider,
         array $data = []
     ) {
         parent::__construct(
@@ -101,6 +84,7 @@ class Button extends AbstractButton implements ShortcutInterface
             $scopeConfig,
             $adyenHelper,
             $adyenConfigHelper,
+            $agreementsProvider,
             $data
         );
         $this->defaultConfigProvider = $defaultConfigProvider;

--- a/Block/Buttons/AbstractButton.php
+++ b/Block/Buttons/AbstractButton.php
@@ -14,17 +14,16 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Block\Buttons;
 
 use Adyen\Payment\Helper\Config;
+use Adyen\ExpressCheckout\Model\AgreementsProvider;
 use Adyen\Payment\Helper\Data as AdyenHelper;
 use Magento\Checkout\Model\Session;
 use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Payment\Model\MethodInterface;
-use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -38,54 +37,60 @@ abstract class AbstractButton extends Template
     /**
      * @var Session
      */
-    private $checkoutSession;
+    protected $checkoutSession;
 
     /**
      * @var MethodInterface
      */
-    private $payment;
+    protected $payment;
 
     /**
      * @var UrlInterface $url
      */
-    private $url;
+    protected $url;
 
     /**
      * @var CustomerSession $customerSession
      */
-    private $customerSession;
+    protected $customerSession;
 
     /**
      * @var StoreManagerInterface $storeManager
      */
-    private $storeManager;
+    protected $storeManager;
 
     /**
      * @var ScopeConfigInterface $scopeConfig
      */
-    private $scopeConfig;
+    protected $scopeConfig;
 
     /**
      * @var AdyenHelper
      */
-    private $adyenHelper;
+    protected $adyenHelper;
 
     /**
      * @var Config
      */
-    private $adyenConfigHelper;
+    protected $adyenConfigHelper;
 
     /**
-     * Button constructor.
-     * @param Context $context
-     * @param Session $checkoutSession
-     * @param MethodInterface $payment
-     * @param UrlInterface $url
-     * @param CustomerSession $customerSession
-     * @param StoreManagerInterface $storeManagerInterface
-     * @param ScopeConfigInterface $scopeConfig
-     * @param AdyenHelper $adyenHelper
-     * @param Config $adyenConfigHelper
+     * @var AgreementsProvider
+     */
+    protected $agreementsProvider;
+
+    /**
+     * AbstractButton Constructor
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Payment\Model\MethodInterface $payment
+     * @param \Magento\Framework\UrlInterface $url
+     * @param \Magento\Customer\Model\Session $customerSession
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Helper\Config $adyenConfigHelper
+     * @param \Adyen\ExpressCheckout\Model\AgreementsProvider $agreementsProvider
      * @param array $data
      */
     public function __construct(
@@ -98,6 +103,7 @@ abstract class AbstractButton extends Template
         ScopeConfigInterface $scopeConfig,
         AdyenHelper $adyenHelper,
         Config $adyenConfigHelper,
+        AgreementsProvider $agreementsProvider,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -254,5 +260,13 @@ abstract class AbstractButton extends Template
     public function getContainerId(): string
     {
         return $this->getData(self::BUTTON_ELEMENT_INDEX) ?: '';
+    }
+
+    /**
+     * @return array
+     */
+    public function getAgreementIds(): array
+    {
+        return $this->agreementsProvider->getRequiredAgreementIds();
     }
 }

--- a/Block/Buttons/AbstractButton.php
+++ b/Block/Buttons/AbstractButton.php
@@ -267,6 +267,6 @@ abstract class AbstractButton extends Template
      */
     public function getAgreementIds(): array
     {
-        return $this->agreementsProvider->getRequiredAgreementIds();
+        return $this->agreementsProvider->getAgreementIds();
     }
 }

--- a/Block/GooglePay/Shortcut/Button.php
+++ b/Block/GooglePay/Shortcut/Button.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Block\GooglePay\Shortcut;
 
+use Adyen\ExpressCheckout\Model\AgreementsProvider;
 use Adyen\Payment\Helper\Data as AdyenHelper;
 use Adyen\Payment\Helper\Config as AdyenConfigHelper;
 use Adyen\ExpressCheckout\Block\Buttons\AbstractButton;
@@ -37,38 +38,19 @@ class Button extends AbstractButton implements ShortcutInterface
     private $defaultConfigProvider;
 
     /**
-     * @var UrlInterface $url
-     */
-    private $url;
-
-    /**
-     * @var CustomerSession $customerSession
-     */
-    private $customerSession;
-
-    /**
-     * @var StoreManagerInterface $storeManager
-     */
-    private $storeManager;
-
-    /**
-     * @var ScopeConfigInterface $scopeConfig
-     */
-    private $scopeConfig;
-
-    /**
-     * Button constructor
+     * Button Constructor
      *
-     * @param Context $context
-     * @param Session $checkoutSession
-     * @param MethodInterface $payment
-     * @param UrlInterface $url
-     * @param CustomerSession $customerSession
-     * @param StoreManagerInterface $storeManagerInterface
-     * @param DefaultConfigProvider $defaultConfigProvider
-     * @param ScopeConfigInterface $scopeConfig
-     * @param AdyenHelper $adyenHelper
-     * @param AdyenConfigHelper $adyenConfigHelper
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Payment\Model\MethodInterface $payment
+     * @param \Magento\Framework\UrlInterface $url
+     * @param \Magento\Customer\Model\Session $customerSession
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
+     * @param \Magento\Checkout\Model\DefaultConfigProvider $defaultConfigProvider
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Helper\Config $adyenConfigHelper
+     * @param \Adyen\ExpressCheckout\Model\AgreementsProvider $agreementsProvider
      * @param array $data
      */
     public function __construct(
@@ -82,6 +64,7 @@ class Button extends AbstractButton implements ShortcutInterface
         ScopeConfigInterface $scopeConfig,
         AdyenHelper $adyenHelper,
         AdyenConfigHelper $adyenConfigHelper,
+        AgreementsProvider $agreementsProvider,
         array $data = []
     ) {
         parent::__construct(
@@ -94,6 +77,7 @@ class Button extends AbstractButton implements ShortcutInterface
             $scopeConfig,
             $adyenHelper,
             $adyenConfigHelper,
+            $agreementsProvider,
             $data
         );
         $this->defaultConfigProvider = $defaultConfigProvider;

--- a/Model/AgreementsProvider.php
+++ b/Model/AgreementsProvider.php
@@ -13,38 +13,50 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Model;
 
-use Magento\CheckoutAgreements\Model\AgreementsProviderInterface;
+use Magento\CheckoutAgreements\Model\AgreementsConfigProvider;
 
 /**
  * Class AgreementsProvider
  *
  * @package Reflet\AdyenExpressCheckout\Model
  */
-class AgreementsProvider implements AgreementsProviderInterface
+class AgreementsProvider
 {
-    protected array $list = [];
+    /**
+     * @var AgreementsConfigProvider
+     */
+    protected $provider;
 
     /**
      * AgreementsProvider Constructor
      *
-     * @param AgreementsProviderInterface[] $list
+     * @param AgreementsConfigProvider $agreementsConfigProvider
      */
     public function __construct(
-        array $list = []
+        AgreementsConfigProvider $agreementsConfigProvider
     ) {
-        $this->list = $list;
+        $this->provider = $agreementsConfigProvider;
     }
 
     /**
-     * @inheritDoc
+     * @return array
      */
-    public function getRequiredAgreementIds(): array
+    public function getAgreementIds(): array
     {
-        $ids = [];
-        foreach ($this->list as $provider) {
-            $ids = array_merge($ids, $provider->getRequiredAgreementIds());
+        $checkoutAgreements = $this->agreementsConfigProvider->getConfig();
+        $agreements = $checkoutAgreements['checkoutAgreements']['agreements'] ?? null;
+        if (!is_array($agreements)) {
+            return [];
         }
 
-        return array_merge($ids);
+        $ids = [];
+        foreach ($agreements as $agreement) {
+            $id = $agreement['agreementId'] ?? null;
+            if ($id) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
     }
 }

--- a/Model/AgreementsProvider.php
+++ b/Model/AgreementsProvider.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model;
+
+use Magento\CheckoutAgreements\Model\AgreementsProviderInterface;
+
+/**
+ * Class AgreementsProvider
+ *
+ * @package Reflet\AdyenExpressCheckout\Model
+ */
+class AgreementsProvider implements AgreementsProviderInterface
+{
+    protected array $list = [];
+
+    /**
+     * AgreementsProvider Constructor
+     *
+     * @param AgreementsProviderInterface[] $list
+     */
+    public function __construct(
+        array $list = []
+    ) {
+        $this->list = $list;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRequiredAgreementIds(): array
+    {
+        $ids = [];
+        foreach ($this->list as $provider) {
+            $ids = array_merge($ids, $provider->getRequiredAgreementIds());
+        }
+
+        return array_merge($ids);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -68,4 +68,12 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Adyen\ExpressCheckout\Model\AgreementsProvider">
+        <arguments>
+            <argument name="list" xsi:type="array">
+                <item name="checkoutAgreements" xsi:type="object">\Magento\CheckoutAgreements\Model\AgreementsProvider</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/view/frontend/templates/applepay/shortcut.phtml
+++ b/view/frontend/templates/applepay/shortcut.phtml
@@ -26,6 +26,7 @@ $config = [
         'checkoutenv' => $block->getCheckoutEnvironment(),
         'isProductView' => (bool) $block->getIsProductView(),
         'buttonColor' => $block->getButtonColor(),
+        'agreementIds' => $block->getAgreementIds(),
     ]
 ];
 ?>

--- a/view/frontend/templates/googlepay/shortcut.phtml
+++ b/view/frontend/templates/googlepay/shortcut.phtml
@@ -24,7 +24,8 @@ $config = [
         'locale' => $block->getLocale(),
         'originkey' => $block->getOriginKey(),
         'checkoutenv' => $block->getCheckoutEnvironment(),
-        'isProductView' => (bool) $block->getIsProductView()
+        'isProductView' => (bool) $block->getIsProductView(),
+        'agreementIds' => $block->getAgreementIds(),
     ]
 ];
 ?>

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -27,7 +27,8 @@ define([
     'Adyen_ExpressCheckout/js/model/config',
     'Adyen_ExpressCheckout/js/model/countries',
     'Adyen_ExpressCheckout/js/model/totals',
-    'Adyen_ExpressCheckout/js/model/currency'
+    'Adyen_ExpressCheckout/js/model/currency',
+    'Adyen_ExpressCheckout/js/helpers/agreementsAssigner',
 ],
     function (
         Component,
@@ -58,7 +59,8 @@ define([
         configModel,
         countriesModel,
         totalsModel,
-        currencyModel
+        currencyModel,
+        agreementsAssigner
     ) {
         'use strict';
 
@@ -489,11 +491,7 @@ define([
                         }
                     };
 
-                    if (window.checkout && window.checkout.agreementIds) {
-                        postData.paymentMethod.extension_attributes = {
-                            agreement_ids: window.checkout.agreementIds
-                        };
-                    }
+                    postData.paymentMethod = agreementsAssigner(postData.paymentMethod);
 
                     createPayment(JSON.stringify(postData), this.isProductView)
                         .done(function () {

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -33,6 +33,7 @@ define([
     'Adyen_ExpressCheckout/js/model/countries',
     'Adyen_ExpressCheckout/js/model/totals',
     'Adyen_ExpressCheckout/js/model/currency',
+    'Adyen_ExpressCheckout/js/helpers/agreementsAssigner',
     'mage/cookies',
 ],
     function (
@@ -69,7 +70,8 @@ define([
         configModel,
         countriesModel,
         totalsModel,
-        currencyModel
+        currencyModel,
+        agreementsAssigner,
     ) {
         'use strict';
 
@@ -389,11 +391,7 @@ define([
                             }
                         };
 
-                        if (window.checkout && window.checkout.agreementIds) {
-                            payload.paymentMethod.extension_attributes = {
-                                agreement_ids: window.checkout.agreementIds
-                            };
-                        }
+                        payload.paymentMethod = agreementsAssigner(payload.paymentMethod);
 
                         createPayment(JSON.stringify(payload), this.isProductView)
                             .done( function (orderId) {

--- a/view/frontend/web/js/helpers/agreementsAssigner.js
+++ b/view/frontend/web/js/helpers/agreementsAssigner.js
@@ -1,0 +1,19 @@
+define([
+    'Adyen_ExpressCheckout/js/model/config',
+], function (configModel) {
+    'use strict';
+
+    return function (paymentData) {
+        const config = configModel().getConfig();
+        const agreementIds = config?.agreementIds ?? null;
+
+        if (Array.isArray(agreementIds) && agreementIds.length > 0) {
+            if (paymentData['extension_attributes'] === undefined) {
+                paymentData['extension_attributes'] = {};
+            }
+
+            paymentData['extension_attributes']['agreement_ids'] = agreementIds;
+        }
+        return paymentData;
+    };
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

This MR corrects the following error: `The order wasn't placed. First, agree to the terms and conditions, then try placing your order again.`

Until now the agreeements were retrieved via the variable `window.checkout.agreementIds`, this variable does not exist (in Adyen and Magento, the agreements are passed directly in the `data-mage-init`.

💎 I passed the properties of the AbstractButton class to protected in order not to dupplicate the code in the children class:)

**Fixed issue**:  #66 
