### PR TITLE
[ECP-8770-v1] Fix shipping method parsing error

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -281,6 +281,7 @@ define([
                         .then(() => getShippingMethods(payload, this.isProductView))
                         .then(function (response) {
 
+                        // If the shipping_method is not available, remove it from the response array.
                         for (let key in response) {
                             if (response[key].available === false) {
                                 response.splice(key, 1);

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -280,7 +280,14 @@ define([
                     activateCart(this.isProductView)
                         .then(() => getShippingMethods(payload, this.isProductView))
                         .then(function (response) {
-                            // Stop if no shipping methods.
+
+                        for (let key in response) {
+                            if (response[key].available === false) {
+                                response.splice(key, 1);
+                            }
+                        }
+
+                        // Stop if no shipping methods.
                         if (response.length === 0) {
                             reject($t('There are no shipping methods available for you right now. Please try again or use an alternative payment method.'));
                             return;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Adobe Commerce provides the opportunity to show the shopping method even though it's not available for the given card. This behaviour can be applied by setting the value of `Configuration / Sales / Shipping Method / Free Shipping / 
Show Method if Not Applicable` config field to `Yes`.

Even though the shipping method is transferred to the frontend, `method_code` of this shipping method will be empty. This triggers the issue of undefined method_code.

This PR solves this issue by unsetting the shipping method if it's not available just by checking the value of `available` property.

## Tested scenarios
<!-- Description of tested scenarios -->
- Two shipping methods of which one of them is unavailable but set to be shown on the checkout.
