### PR TITLE
[ECP-8907] - Fix Google Pay redirect to success page after payment

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -29,6 +29,8 @@ define([
     'Adyen_ExpressCheckout/js/helpers/redirectToSuccess',
     'Adyen_ExpressCheckout/js/helpers/setExpressMethods',
     'Adyen_ExpressCheckout/js/helpers/validatePdpForm',
+    'Adyen_ExpressCheckout/js/helpers/getMaskedIdFromCart',
+    'Adyen_ExpressCheckout/js/model/maskedId',
     'Adyen_ExpressCheckout/js/model/config',
     'Adyen_ExpressCheckout/js/model/countries',
     'Adyen_ExpressCheckout/js/model/totals',
@@ -66,6 +68,8 @@ define([
         redirectToSuccess,
         setExpressMethods,
         validatePdpForm,
+        getMaskedIdFromCart,
+        maskedIdModel,
         configModel,
         countriesModel,
         totalsModel,
@@ -407,7 +411,8 @@ define([
                             .done( function (orderId) {
                                 if (!!orderId) {
                                     self.orderId = orderId;
-                                    adyenPaymentService.getOrderPaymentStatus(orderId).
+                                    let quoteId = self.isProductView ? maskedIdModel().getMaskedId() : getMaskedIdFromCart();
+                                    adyenPaymentService.getOrderPaymentStatus(orderId, quoteId).
                                     done(function (responseJSON) {
                                         self.handleAdyenResult(responseJSON, orderId);
                                     })


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After the changes on V9 of main payment module, it was seen that Google Pay express couldn't redirect shopper to success page. The issue was main module couldn't fetch the `quoteId` from `quote` object on product detail page. Because, `quote` object is not available at that moment.

This PR applies the fix [2462](https://github.com/Adyen/adyen-magento2/pull/2462) to express module repository.

## Tested scenarios
<!-- Description of tested scenarios -->
- Tested Googlepay payment on product, cart and minicart view. 