### PR TITLE
[ECP-9114] Implement /payments endpoint for express use cases

### DIFF
--- a/Api/AdyenInitPaymentsInterface.php
+++ b/Api/AdyenInitPaymentsInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Api;
+
+interface AdyenInitPaymentsInterface
+{
+    const PAYMENT_CHANNEL_WEB = 'web';
+
+    /**
+     * @param int $adyenCartId
+     * @param string $stateData
+     * @return string
+     */
+    public function execute(int $adyenCartId, string $stateData): string;
+}

--- a/Api/GuestAdyenInitPaymentsInterface.php
+++ b/Api/GuestAdyenInitPaymentsInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Api;
+
+interface GuestAdyenInitPaymentsInterface
+{
+    /**
+     * @param string $maskedQuoteId
+     * @param string $stateData
+     * @return string
+     */
+    public function execute(string $maskedQuoteId, string $stateData): string;
+}

--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model;
+
+use Adyen\ExpressCheckout\Api\AdyenInitPaymentsInterface;
+use Adyen\Payment\Gateway\Http\Client\TransactionPayment;
+use Adyen\Payment\Gateway\Http\TransferFactory;
+use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\PaymentResponseHandler;
+use Adyen\Payment\Helper\ReturnUrlHelper;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Exception;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+
+class AdyenInitPayments implements AdyenInitPaymentsInterface
+{
+    /**
+     * @var CartRepositoryInterface
+     */
+    private CartRepositoryInterface $cartRepository;
+
+    /**
+     * @var Config
+     */
+    private Config $configHelper;
+
+    /**
+     * @var ChargedCurrency
+     */
+    private ChargedCurrency $chargedCurrency;
+
+    /**
+     * @var ReturnUrlHelper
+     */
+    private ReturnUrlHelper $returnUrlHelper;
+
+    /**
+     * @var CheckoutStateDataValidator
+     */
+    private CheckoutStateDataValidator $checkoutStateDataValidator;
+
+    /**
+     * @var TransferFactory
+     */
+    private TransferFactory $transferFactory;
+
+    /**
+     * @var TransactionPayment
+     */
+    private TransactionPayment $transactionPaymentClient;
+
+    /**
+     * @var Data
+     */
+    private Data $adyenHelper;
+
+    /**
+     * @var PaymentResponseHandler
+     */
+    private PaymentResponseHandler $paymentResponseHandler;
+
+    /**
+     * @param CartRepositoryInterface $cartRepository
+     * @param Config $configHelper
+     * @param ChargedCurrency $chargedCurrency
+     * @param ReturnUrlHelper $returnUrlHelper
+     * @param CheckoutStateDataValidator $checkoutStateDataValidator
+     * @param TransferFactory $transferFactory
+     * @param TransactionPayment $transactionPaymentClient
+     * @param Data $adyenHelper
+     * @param PaymentResponseHandler $paymentResponseHandler
+     */
+    public function __construct(
+        CartRepositoryInterface $cartRepository,
+        Config $configHelper,
+        ChargedCurrency $chargedCurrency,
+        ReturnUrlHelper $returnUrlHelper,
+        CheckoutStateDataValidator $checkoutStateDataValidator,
+        TransferFactory $transferFactory,
+        TransactionPayment $transactionPaymentClient,
+        Data $adyenHelper,
+        PaymentResponseHandler $paymentResponseHandler
+    ) {
+        $this->cartRepository = $cartRepository;
+        $this->configHelper = $configHelper;
+        $this->chargedCurrency = $chargedCurrency;
+        $this->returnUrlHelper = $returnUrlHelper;
+        $this->checkoutStateDataValidator = $checkoutStateDataValidator;
+        $this->transferFactory = $transferFactory;
+        $this->transactionPaymentClient = $transactionPaymentClient;
+        $this->adyenHelper = $adyenHelper;
+        $this->paymentResponseHandler = $paymentResponseHandler;
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ValidatorException
+     * @throws ClientException
+     */
+    public function execute(int $adyenCartId, string $stateData): string
+    {
+        /** @var Quote $quote */
+        $quote = $this->cartRepository->get($adyenCartId);
+        // Reserve an order ID for the quote to obtain the reference and save the quote
+        if (is_null($quote->getReservedOrderId())) {
+            $quote = $quote->reserveOrderId();
+            $this->cartRepository->save($quote);
+        }
+
+        $stateData = json_decode($stateData, true);
+        // Validate JSON that has just been parsed if it was in a valid format
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new ValidatorException(
+                __('Payments call failed because stateData was not a valid JSON!')
+            );
+        }
+
+        // Validate the keys in stateData and remove invalid keys
+        $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
+        $paymentsRequest = $this->buildPaymentsRequest($quote, $stateData);
+
+        $transfer = $this->transferFactory->create([
+            'body' => $paymentsRequest,
+            'clientConfig' => ['storeId' => $quote->getStoreId()]
+        ]);
+
+        try {
+            $response = $this->transactionPaymentClient->placeRequest($transfer);
+            return json_encode(
+                $this->paymentResponseHandler->formatPaymentResponse($response['resultCode'], $response['action'])
+            );
+        } catch (Exception $e) {
+            throw new ClientException(
+                __('Error with payment method, please select a different payment method!')
+            );
+        }
+    }
+
+    /**
+     * @param Quote $quote
+     * @param array $stateData
+     * @return array
+     */
+    protected function buildPaymentsRequest(Quote $quote, array $stateData): array
+    {
+        $chargedQuoteCurrency = $this->chargedCurrency->getQuoteAmountCurrency($quote);
+        $currency = $chargedQuoteCurrency->getCurrencyCode();
+
+        $merchantReference = $quote->getReservedOrderId();
+        $storeId = $quote->getStoreId();
+        $returnUrl = sprintf(
+            "%s?merchantReference=%s",
+            $this->returnUrlHelper->getStoreReturnUrl($storeId),
+            $merchantReference
+        );
+
+        $request = [
+            'amount' => [
+                'currency' => $currency,
+                'value' => $this->adyenHelper->formatAmount($chargedQuoteCurrency->getAmount(), $currency)
+            ],
+            'reference' => $merchantReference,
+            'returnUrl' => $returnUrl,
+            'merchantAccount' => $this->configHelper->getMerchantAccount($storeId),
+            'channel' => self::PAYMENT_CHANNEL_WEB
+        ];
+
+        return array_merge($request, $stateData);
+    }
+}

--- a/Model/GuestAdyenInitPayments.php
+++ b/Model/GuestAdyenInitPayments.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model;
+
+use Adyen\ExpressCheckout\Api\GuestAdyenInitPaymentsInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+
+class GuestAdyenInitPayments implements GuestAdyenInitPaymentsInterface
+{
+    /**
+     * @var QuoteIdMaskFactory
+     */
+    private QuoteIdMaskFactory $quoteIdMaskFactory;
+
+    /**
+     * @var AdyenInitPayments
+     */
+    private AdyenInitPayments $adyenInitPayments;
+
+    /**
+     * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param AdyenInitPayments $adyenInitPayments
+     */
+    public function __construct(
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        AdyenInitPayments $adyenInitPayments
+    ) {
+        $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->adyenInitPayments = $adyenInitPayments;
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ValidatorException
+     * @throws ClientException
+     */
+    public function execute(string $maskedQuoteId, string $stateData): string
+    {
+        $quoteIdMask = $this->quoteIdMaskFactory->create()->load($maskedQuoteId, 'masked_id');
+        $quoteId = (int) $quoteIdMask->getQuoteId();
+
+        return $this->adyenInitPayments->execute($quoteId, $stateData);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,6 +26,8 @@
     <preference for="Adyen\ExpressCheckout\Api\Data\ProductCartParamsInterface" type="Adyen\ExpressCheckout\Model\ProductCartParams" />
     <preference for="Adyen\ExpressCheckout\Api\Data\MethodResponse\ConfigurationInterface" type="Adyen\ExpressCheckout\Model\MethodResponse\Configuration" />
     <preference for="Adyen\ExpressCheckout\Api\Data\AdyenPaymentMethodsInterface" type="Adyen\ExpressCheckout\Model\AdyenPaymentMethods" />
+    <preference for="Adyen\ExpressCheckout\Api\AdyenInitPaymentsInterface" type="Adyen\ExpressCheckout\Model\AdyenInitPayments" />
+    <preference for="Adyen\ExpressCheckout\Api\GuestAdyenInitPaymentsInterface" type="Adyen\ExpressCheckout\Model\GuestAdyenInitPayments" />
     <preference for="Adyen\ExpressCheckout\Model\ConfigurationInterface" type="Adyen\ExpressCheckout\Model\Configuration" />
     <preference for="Adyen\ExpressCheckout\Model\ExpressDataBuilderInterface" type="Adyen\ExpressCheckout\Model\ExpressDataBuilder" />
     <preference for="Adyen\ExpressCheckout\Model\GetAdyenPaymentMethodsByProductInterface" type="Adyen\ExpressCheckout\Model\GetAdyenPaymentMethodsByProduct" />

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -59,4 +59,20 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <!-- /payments endpoint to initiate Adyen offer -->
+    <route url="/V1/adyen/express/init-payments/mine" method="POST">
+        <service class="Adyen\ExpressCheckout\Api\AdyenInitPaymentsInterface" method="execute"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="adyenCartId" force="true">%adyen_cart_id%</parameter>
+        </data>
+    </route>
+    <route url="/V1/adyen/express/init-payments/guest" method="POST">
+        <service class="Adyen\ExpressCheckout\Api\GuestAdyenInitPaymentsInterface" method="execute"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR creates a new endpoint the express module initiate `/payments` endpoint from Adyen's Checkout API. This endpoint doesn't not trigger the payment authorization command pool from payment method facade but makes an individual call to initiate offer on Adyen side.

**Endpoint for guest shoppers**
`/V1/adyen/express/init-payments/guest`
Required parameters:
  - `maskedQuoteId`
  - 'stateData`

**Endpoint for logged-in shoppers**
`/V1/adyen/express/init-payments/mine`
Required parameters:
  - 'stateData`

## Tested scenarios
<!-- Description of tested scenarios -->
- Initiate /payments call and obtain `pspreference` and `paymentData` for PayPal express.