### PR TITLE
[ECP-9230] Prevent refreshing Quote ID during page refresh on product page for express payment

### DIFF
--- a/view/frontend/web/js/actions/getExpressMethods.js
+++ b/view/frontend/web/js/actions/getExpressMethods.js
@@ -22,44 +22,48 @@ define([
         getRequest: function (element) {
             const existingRequest = this.request();
 
-            if (!existingRequest) {
-                const pdpForm = getPdpForm(element);
-                const formData = getFormData(pdpForm);
-                const cartMaskedId = getMaskedIdFromCart();
-                const adyenMaskedQuoteId = maskedIdModel().getMaskedId();
-                const payload = {
-                    productCartParams: {
-                        product: formData['product'],
-                        qty: formData['qty'],
-                        super_attribute: formData['super_attribute']
-                    }
-                };
-                const url = getIsLoggedIn()
-                    ? 'rest/V1/adyen/express/init/mine'
-                    : 'rest/V1/adyen/express/init/guest';
-
-                if (cartMaskedId) {
-                    payload.guestMaskedId = cartMaskedId;
-                }
-
-                if (adyenMaskedQuoteId) {
-                    payload.adyenMaskedQuoteId = adyenMaskedQuoteId;
-                }
-
-                const request = storage.post(
-                    url,
-                    JSON.stringify(payload)
-                ).done(function (response) {
-                    this.request(null);
-                    return response;
-                }.bind(this));
-
-                this.request(request);
-
-                return request;
+            if (existingRequest) {
+                return existingRequest;
             }
 
-            return existingRequest;
+            const pdpForm = getPdpForm(element);
+            const formData = getFormData(pdpForm);
+            const cartMaskedId = getMaskedIdFromCart();
+
+            const lastQuoteId = localStorage.getItem("lastQuoteId");
+            // console.log(lastQuoteId);
+            const adyenMaskedQuoteId = lastQuoteId != null ? lastQuoteId : maskedIdModel().getMaskedId();
+
+            const payload = {
+                productCartParams: {
+                    product: formData['product'],
+                    qty: formData['qty'],
+                    super_attribute: formData['super_attribute']
+                }
+            };
+            const url = getIsLoggedIn()
+                ? 'rest/V1/adyen/express/init/mine'
+                : 'rest/V1/adyen/express/init/guest';
+
+            if (cartMaskedId) {
+                payload.guestMaskedId = cartMaskedId;
+            }
+
+            if (adyenMaskedQuoteId) {
+                payload.adyenMaskedQuoteId = adyenMaskedQuoteId;
+            }
+
+            const request = storage.post(
+                url,
+                JSON.stringify(payload)
+            ).done(function (response) {
+                this.request(null);
+                return response;
+            }.bind(this));
+
+            this.request(request);
+
+            return request;
         }
     });
 });

--- a/view/frontend/web/js/actions/getExpressMethods.js
+++ b/view/frontend/web/js/actions/getExpressMethods.js
@@ -30,9 +30,8 @@ define([
             const formData = getFormData(pdpForm);
             const cartMaskedId = getMaskedIdFromCart();
 
-            const lastQuoteId = localStorage.getItem("lastQuoteId");
-            // console.log(lastQuoteId);
-            const adyenMaskedQuoteId = lastQuoteId != null ? lastQuoteId : maskedIdModel().getMaskedId();
+            const previousQuoteId = localStorage.getItem("quoteId");
+            const adyenMaskedQuoteId = previousQuoteId != null ? previousQuoteId : maskedIdModel().getMaskedId();
 
             const payload = {
                 productCartParams: {

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -25,6 +25,7 @@ define([
     'Adyen_ExpressCheckout/js/helpers/redirectToSuccess',
     'Adyen_ExpressCheckout/js/helpers/setExpressMethods',
     'Adyen_ExpressCheckout/js/helpers/validatePdpForm',
+    'Adyen_ExpressCheckout/js/helpers/manageQuoteIdOnPageRefresh',
     'Adyen_ExpressCheckout/js/model/config',
     'Adyen_ExpressCheckout/js/model/countries',
     'Adyen_ExpressCheckout/js/model/totals',
@@ -58,6 +59,7 @@ define([
         redirectToSuccess,
         setExpressMethods,
         validatePdpForm,
+        manageQuoteIdOnPageRefresh,
         configModel,
         countriesModel,
         totalsModel,
@@ -80,11 +82,14 @@ define([
                 configModel().setConfig(config);
                 countriesModel();
 
+                await manageQuoteIdOnPageRefresh();
                 this.isProductView = config.isProductView;
 
                 // If express methods is not set then set it.
                 if (this.isProductView) {
                     const response = await getExpressMethods().getRequest(element);
+
+                    localStorage.setItem("quoteId", response.masked_quote_id);
                     const cart = customerData.get('cart');
 
                     virtualQuoteModel().setIsVirtual(true, response);
@@ -139,6 +144,15 @@ define([
                     }
                 }
             },
+
+            // manageQuoteIdOnPageRefresh: async function(){
+            //     const navigationEntries = performance.getEntriesByType('navigation');
+            //     const pageAccessedByReload = navigationEntries.length > 0 &&
+            //         navigationEntries[0].type === 'reload';
+            //     if(!pageAccessedByReload){
+            //         localStorage.removeItem("quoteId");
+            //     }
+            // },
 
             initialiseApplePayComponent: async function (applePaymentMethod, element) {
                 const config = configModel().getConfig();

--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -145,15 +145,6 @@ define([
                 }
             },
 
-            // manageQuoteIdOnPageRefresh: async function(){
-            //     const navigationEntries = performance.getEntriesByType('navigation');
-            //     const pageAccessedByReload = navigationEntries.length > 0 &&
-            //         navigationEntries[0].type === 'reload';
-            //     if(!pageAccessedByReload){
-            //         localStorage.removeItem("quoteId");
-            //     }
-            // },
-
             initialiseApplePayComponent: async function (applePaymentMethod, element) {
                 const config = configModel().getConfig();
                 const adyenData = window.adyenData;

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -137,14 +137,14 @@ define([
                 const pageAccessedByReload = navigationEntries.length > 0 &&
                     navigationEntries[0].type === 'reload';
                 if(!pageAccessedByReload){
-                    localStorage.removeItem("lastQuoteId");
+                    localStorage.removeItem("quoteId");
                 }
             },
 
             initializeOnPDP: async function (config, element) {
                 const response = await getExpressMethods().getRequest(element);
 
-                localStorage.setItem("lastQuoteId", response.masked_quote_id)
+                localStorage.setItem("quoteId", response.masked_quote_id)
 
                 const cart = customerData.get('cart');
                 virtualQuoteModel().setIsVirtual(true, response);

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -134,45 +134,48 @@ define([
             initializeOnPDP: async function (config, element) {
                 debugger;
                 // const response = await getExpressMethods().getRequest(element);
-                await getExpressMethods().getRequest(element).then(response => {
-                                        console.log(response);
-                                    }).catch(error => {
-                                        console.error(error);
-                                    });
-                const cart = customerData.get('cart');
-                virtualQuoteModel().setIsVirtual(true, response);
+                const self = this;
+                await getExpressMethods()
+                    .getRequest(element)
+                    .then(async function (response) {
+                        console.log(response);
+                        const cart = customerData.get('cart');
+                        virtualQuoteModel().setIsVirtual(true, response);
 
-                cart.subscribe(function () {
-                    this.reloadGooglePayButton(element);
-                }.bind(this));
-
-                setExpressMethods(response);
-                totalsModel().setTotal(response.totals.grand_total);
-                currencyModel().setCurrency(response.totals.quote_currency_code)
-
-                const $priceBox = getPdpPriceBox();
-                const pdpForm = getPdpForm(element);
-
-                $priceBox.on('priceUpdated', async function () {
-                    const isValid = new Promise((resolve, reject) => {
-                        return validatePdpForm(resolve, reject, pdpForm, true);
-                    });
-
-                    isValid
-                        .then(function () {
+                        cart.subscribe(function () {
                             this.reloadGooglePayButton(element);
-                        }.bind(this))
-                        .catch(function (error) {
-                            console.log(error);
-                        });
-                }.bind(this));
+                        }.bind(self));
 
-                let googlePaymentMethod = await getPaymentMethod('googlepay', this.isProductView);
+                        setExpressMethods(response);
+                        totalsModel().setTotal(response.totals.grand_total);
+                        currencyModel().setCurrency(response.totals.quote_currency_code)
 
-                if (!isConfigSet(googlePaymentMethod, ['gatewayMerchantId', 'merchantId'])) {
-                }
+                        const $priceBox = getPdpPriceBox();
+                        const pdpForm = getPdpForm(element);
 
-                this.initialiseGooglePayComponent(googlePaymentMethod, element);
+                        $priceBox.on('priceUpdated', async function () {
+                            const isValid = new Promise((resolve, reject) => {
+                                return validatePdpForm(resolve, reject, pdpForm, true);
+                            });
+
+                            isValid
+                                .then(function () {
+                                    this.reloadGooglePayButton(element);
+                                }.bind(this))
+                                .catch(function (error) {
+                                    console.log(error);
+                                });
+                        }.bind(self));
+
+                        let googlePaymentMethod = await getPaymentMethod('googlepay', self.isProductView);
+
+                        if (!isConfigSet(googlePaymentMethod, ['gatewayMerchantId', 'merchantId'])) {
+                        }
+
+                        self.initialiseGooglePayComponent(googlePaymentMethod, element);
+                    }).catch(function (error) {
+                        console.log(error);
+                    });
             },
 
             initialiseGooglePayComponent: async function (googlePaymentMethod, element) {

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -32,6 +32,7 @@ define([
     'Adyen_ExpressCheckout/js/helpers/setExpressMethods',
     'Adyen_ExpressCheckout/js/helpers/validatePdpForm',
     'Adyen_ExpressCheckout/js/helpers/getMaskedIdFromCart',
+    'Adyen_ExpressCheckout/js/helpers/manageQuoteIdOnPageRefresh',
     'Adyen_ExpressCheckout/js/model/maskedId',
     'Adyen_ExpressCheckout/js/model/config',
     'Adyen_ExpressCheckout/js/model/countries',
@@ -74,6 +75,7 @@ define([
         validatePdpForm,
         getMaskedIdFromCart,
         maskedIdModel,
+        manageQuoteIdOnPageRefresh,
         configModel,
         countriesModel,
         totalsModel,
@@ -107,7 +109,7 @@ define([
                 configModel().setConfig(config);
                 countriesModel();
 
-                await this.manageQuoteIdOnPageRefresh();
+                await manageQuoteIdOnPageRefresh();
                 this.isProductView = config.isProductView;
 
                 // If express methods is not set then set it.
@@ -132,20 +134,10 @@ define([
                 }
             },
 
-            manageQuoteIdOnPageRefresh: async function(){
-                const navigationEntries = performance.getEntriesByType('navigation');
-                const pageAccessedByReload = navigationEntries.length > 0 &&
-                    navigationEntries[0].type === 'reload';
-                if(!pageAccessedByReload){
-                    localStorage.removeItem("quoteId");
-                }
-            },
-
             initializeOnPDP: async function (config, element) {
                 const response = await getExpressMethods().getRequest(element);
 
-                localStorage.setItem("quoteId", response.masked_quote_id)
-
+                localStorage.setItem("quoteId", response.masked_quote_id);
                 const cart = customerData.get('cart');
                 virtualQuoteModel().setIsVirtual(true, response);
 

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -132,7 +132,13 @@ define([
             },
 
             initializeOnPDP: async function (config, element) {
-                const response = await getExpressMethods().getRequest(element);
+                debugger;
+                // const response = await getExpressMethods().getRequest(element);
+                await getExpressMethods().getRequest(element).then(response => {
+                                        console.log(response);
+                                    }).catch(error => {
+                                        console.error(error);
+                                    });
                 const cart = customerData.get('cart');
                 virtualQuoteModel().setIsVirtual(true, response);
 

--- a/view/frontend/web/js/helpers/manageQuoteIdOnPageRefresh.js
+++ b/view/frontend/web/js/helpers/manageQuoteIdOnPageRefresh.js
@@ -1,0 +1,12 @@
+define(function () {
+    'use strict';
+
+    return async function(){
+        const navigationEntries = performance.getEntriesByType('navigation');
+        const pageAccessedByReload = navigationEntries.length > 0 &&
+            navigationEntries[0].type === 'reload';
+        if(!pageAccessedByReload){
+            localStorage.removeItem("quoteId");
+        }
+    };
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
On product page for express checkouts, the quote-id is being created every time the page is refreshed on the browser and as a result a multiple entries exist in the `quote` table for the same product. This happens for both logged in or guest user where quote id is maintained for the session but not through refresh. This PR includes storing the quote-id to JS local storage variable and accessing it whenever `getRequest` method is called, to check whether there is an existing quote-id, if not then  let `getRequest` create a new one.

## Tested scenarios
<!-- Description of tested scenarios -->
1. Quote-id is retained on page refresh
2. On visiting a different product page than the current one, the previous quote-id is removed 

**Fixed issue**:  <!-- #-prefixed issue number -->
