### PR TITLE
Prevents state and status change of non adyen orders

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -8,7 +8,7 @@ define([
     'Magento_Checkout/js/model/quote',
     'Adyen_Payment/js/adyen',
     'Adyen_Payment/js/model/adyen-payment-modal',
-    'Adyen_Payment/js/model/adyen-payment-service',
+    'Adyen_ExpressCheckout/js/model/adyen-payment-service',
     'Adyen_ExpressCheckout/js/actions/activateCart',
     'Adyen_ExpressCheckout/js/actions/cancelCart',
     'Adyen_ExpressCheckout/js/actions/createPayment',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Main issue : Prevents state and status change of non Adyen orders
- Secondary fix : use of repository to save order. $order->save() is deprecated.

## Tested scenarios
Buy product with a payment which does not part of Adyen for instance Paypal built in module. Order state should be "processing" instead of "new" and status should be "processing" instead of "pending". 
Generally speaking order state and status should be changed by payment method and not Adyen payment method 

