### PR TITLE
Solving the issue of broken Order view page after installing express checkout

### DIFF
--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -12,9 +12,6 @@
 -->
 <payment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
     <groups>
-        <group id="adyen">
-            <label>Adyen Payment Methods</label>
-        </group>
         <group id="adyen-express-payment-method">
             <label>Adyen Express Checkout Payment Methods</label>
         </group>

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<payment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
+    <groups>
+        <group id="adyen">
+            <label>Adyen Payment Methods</label>
+        </group>
+        <group id="adyen-express-payment-method">
+            <label>Adyen Express Checkout Payment Methods</label>
+        </group>
+    </groups>
+</payment>

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -4,7 +4,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A new payment method group `adyen-express-payment-method` was introduced for `adyen_paypal_express` payment method, but this group wasn't defined in the `payment.xml` and therefore it was failing to retrieve the label information when it was trying to access `$this->_getOptions()->label` failing in successful displaying the order details page.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
