### PR TITLE
[ECP-9442] Implement expressCancel mutation to cancel express quote on PDP

### DIFF
--- a/Model/Resolver/ExpressCancelResolver.php
+++ b/Model/Resolver/ExpressCancelResolver.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressCancel;
+use Adyen\Payment\Logger\AdyenLogger;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+
+class ExpressCancelResolver implements ResolverInterface
+{
+    /**
+     * @param ExpressCancel $expressCancelApi
+     * @param ValueFactory $valueFactory
+     * @param QuoteIdMaskFactory $quoteMaskFactory
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        public ExpressCancel $expressCancelApi,
+        public ValueFactory $valueFactory,
+        public QuoteIdMaskFactory $quoteMaskFactory,
+        public AdyenLogger $adyenLogger
+    ) { }
+
+    /**
+     * @param Field $field
+     * @param $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return Value|mixed
+     * @throws GraphQlInputException
+     * @throws GraphQlNoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['adyenCartId'])) {
+            throw new GraphQlInputException(__('Required parameter "adyenCartId" is missing!'));
+        }
+
+        try {
+            // Extract unmasked quote id
+            $adyenCartId = $args['adyenCartId'];
+            $quoteIdMask = $this->quoteMaskFactory->create()->load(
+                $adyenCartId,
+                'masked_id'
+            );
+            $quoteId = (int) $quoteIdMask->getQuoteId();
+
+            $provider = $this->expressCancelApi;
+
+            $result = function () use ($quoteId, $provider) {
+                $provider->execute($quoteId);
+                return true;
+            };
+
+            return $this->valueFactory->create($result);
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(__($e->getMessage()));
+        } catch (Exception $e) {
+            $errorMessage = "An error occurred while cancelling the express quote";
+            $logMessage = sprintf("%s: %s", $errorMessage, $e->getMessage());
+            $this->adyenLogger->error($logMessage);
+
+            throw new LocalizedException(__($errorMessage));
+        }
+    }
+}

--- a/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressCancel;
+use Adyen\ExpressCheckout\Model\Resolver\ExpressCancelResolver;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\Context;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ExpressCancelResolverTest extends AbstractAdyenTestCase
+{
+    // Mocks for class builder
+    protected ?ExpressCancelResolver $expressCancelResolver;
+    protected MockObject&ExpressCancel $expressCancelMock;
+    protected MockObject&ValueFactory $valueFactoryMock;
+    protected MockObject&QuoteIdMaskFactory $quoteIdMaskFactoryMock;
+    protected MockObject&AdyenLogger $loggerMock;
+
+    // Mocks for `resolve()` method
+    protected MockObject&Field $fieldMock;
+    protected MockObject&Context $contextMock;
+    protected MockObject&ResolveInfo $infoMock;
+
+
+    public function setUp(): void
+    {
+        $this->expressCancelMock = $this->createMock(ExpressCancel::class);
+        $this->valueFactoryMock = $this->createMock(ValueFactory::class);
+        $this->fieldMock = $this->createMock(Field::class);
+        $this->contextMock = $this->createMock(Context::class);
+        $this->infoMock = $this->createMock(ResolveInfo::class);
+        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(QuoteIdMaskFactory::class, [
+            'create'
+        ]);
+        $this->loggerMock = $this->createMock(AdyenLogger::class);
+
+        $this->expressCancelResolver = new ExpressCancelResolver(
+            $this->expressCancelMock,
+            $this->valueFactoryMock,
+            $this->quoteIdMaskFactoryMock,
+            $this->loggerMock
+        );
+    }
+
+    /**
+     * Reset the target class after each test
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->expressCancelResolver = null;
+    }
+
+    /**
+     * Assets expect exception if the required parameter `adyenCartId` is an empty string.
+     *
+     * @return void
+     * @throws GraphQlInputException|Exception
+     */
+    public function testResolverShouldThrowExceptionWithEmptyArgument()
+    {
+        $this->expectException(GraphQlInputException::class);
+
+        $args = [
+            'adyenCartId' => ""
+        ];
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets expect exception if the masked quote id doesn't belong to any quote
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResolverShouldThrowExceptionNonExistingQuote()
+    {
+        $this->expectException(GraphQlNoSuchEntityException::class);
+
+        $args = [
+            'adyenCartId' => "Mock_adyen_cart_id"
+        ];
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $this->valueFactoryMock->method('create')->willThrowException(new NoSuchEntityException());
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets expect exception if the quote id can not be unmasked
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResolverShouldThrowExceptionInvalidQuoteId()
+    {
+        $this->expectException(LocalizedException::class);
+
+        $args = [
+            'adyenCartId' => "Mock_adyen_cart_id"
+        ];
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willThrowException(new Exception());
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets successful generation of the Value class after resolving
+     * the mutation with correct set of inputs.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulResolving()
+    {
+        $args['adyenCartId'] = "Mock_adyenCartId";
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $returnValueMock = $this->createMock(Value::class);
+        $this->valueFactoryMock->method('create')->willReturn($returnValueMock);
+
+        $result = $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+
+        $this->assertInstanceOf(Value::class, $result);
+    }
+}

--- a/Test/api-functional/GraphQl/AdyenExpressTest.php
+++ b/Test/api-functional/GraphQl/AdyenExpressTest.php
@@ -147,4 +147,41 @@ QUERY;
         $this->assertArrayHasKey('expressActivate', $response);
         $this->assertTrue($response['expressActivate']);
     }
+
+    /**
+     * Test case for expressCancel mutation with valid adyenCartId
+     * should activate the quote and return TRUE.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulExpressQuoteCancellation(): void
+    {
+        // Generate express quote for PDP
+        $query = <<<QUERY
+mutation {
+    expressInit(
+        productCartParams: "{\"product\":1562,\"qty\":\"1\",\"super_attribute\":{\"93\":56,\"144\":166}}"
+    ) {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $initiateQuote = $this->graphQlMutation($query);
+        $expressMaskedQuoteId = $initiateQuote['expressInit']['masked_quote_id'];
+
+        $query = <<<QUERY
+mutation {
+    expressCancel(
+        adyenCartId: "$expressMaskedQuoteId"
+    )
+}
+QUERY;
+
+        $response = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressCancel', $response);
+        $this->assertTrue($response['expressCancel']);
+    }
 }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -9,6 +9,10 @@ type Mutation {
         adyenMaskedQuoteId: String! @doc(description: "Generated masked quote ID for PDP")
         adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
     ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressActivateResolver")
+
+    expressCancel (
+        adyenCartId: String! @doc(description: "Original quote ID of a shopper")
+    ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressCancelResolver")
 }
 
 type ExpressData {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR implements `expressCancel` GraphQL mutation to cancel the express quote generated on product detail page (PDP). Unit and API functional tests were also provided.

## Tested scenarios
<!-- Description of tested scenarios -->
- Unit tests
- API functional tests