### PR TITLE
Implement GraphQL mutations to support headless express payments on PDP

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,58 @@
+ARG PHP_VERSION
+FROM php:${PHP_VERSION}-apache
+LABEL maintainer="Adyen <magento@adyen.com>"
+
+ENV MAGENTO_HOST="<will be defined>" \
+DB_SERVER="<will be defined>" \
+DB_PORT=3306 \
+DB_NAME=magento \
+DB_USER=magento \
+DB_PASSWORD=magento \
+DB_PREFIX=m2_ \
+ELASTICSEARCH_SERVER="<will be defined>" \
+ELASTICSEARCH_PORT=9200 \
+ELASTICSEARCH_INDEX_PREFIX=magento2 \
+ELASTICSEARCH_TIMEOUT=15 \
+ADMIN_NAME=admin \
+ADMIN_LASTNAME=admin \
+ADMIN_EMAIL=admin@example.com \
+ADMIN_USERNAME=admin \
+ADMIN_PASSWORD=admin123 \
+ADMIN_URLEXT=admin \
+MAGENTO_LANGUAGE=en_US \
+MAGENTO_CURRENCY=EUR \
+MAGENTO_TZ=Europe/Amsterdam \
+DEPLOY_SAMPLEDATA=0 \
+USE_SSL=1
+
+RUN apt-get update \
+    && apt-get install -y libjpeg62-turbo-dev \
+        libpng-dev \
+        libfreetype6-dev \
+        libxml2-dev \
+        libzip-dev \
+        libssl-dev \
+        libxslt-dev \
+        default-mysql-client \
+        ssl-cert \
+        wget \
+        cron \
+        unzip
+
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip
+RUN a2enmod ssl
+RUN a2ensite default-ssl.conf #can be removed if not needed
+WORKDIR /var/www/html
+COPY config/php.ini /usr/local/etc/php/
+COPY scripts/install_magento.sh /tmp/install_magento.sh
+
+RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
+
+ARG MAGENTO_VERSION
+ADD "https://github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.tar.gz" /tmp/magento.tar.gz
+ADD "https://github.com/magento/magento2-sample-data/archive/refs/tags/${MAGENTO_VERSION}.tar.gz" /tmp/sample-data.tar.gz
+
+RUN chmod +x /tmp/install_magento.sh
+
+CMD ["bash", "/tmp/install_magento.sh"]

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,0 +1,59 @@
+# Install N98-Magerun
+n98-magerun2.phar:
+	wget -q https://files.magerun.net/n98-magerun2.phar
+	chmod +x ./n98-magerun2.phar
+
+# Check Magento installation
+sys-check: n98-magerun2.phar
+	./n98-magerun2.phar sys:check
+
+# Install Magento (without starting Apache)
+magento:
+	sed '/exec /d' /tmp/install_magento.sh | bash
+
+# Plugin install
+install:
+	composer config --json repositories.local '{"type": "path", "url": "/data/extensions/workdir", "options": { "symlink": false } }'
+	composer require "adyen/adyen-magento2-expresscheckout:*"
+	vendor/bin/phpcs --standard=Magento2 --extensions=php,phtml --error-severity=10 --ignore-annotations -n -p vendor/adyen/adyen-magento2-expresscheckout
+	bin/magento module:enable --all
+	bin/magento setup:upgrade
+	bin/magento setup:di:compile
+
+# Configuration
+configure: n98-magerun2.phar
+	bin/magento config:set payment/adyen_abstract/demo_mode 1
+	bin/magento adyen:enablepaymentmethods:run
+	bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT}"
+	bin/magento config:set payment/adyen_abstract/client_key_test "${ADYEN_CLIENT_KEY}"
+	bin/magento config:set payment/adyen_abstract/payment_methods_active 1
+	bin/magento config:set payment/adyen_googlepay/express_show_on "1,2,3"
+	bin/magento config:set payment/adyen_applepay/express_show_on "1,2,3"
+	./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/notification_password '1234'  > /dev/null
+	./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/api_key_test "${ADYEN_API_KEY}" > /dev/null
+
+# Clear cache
+flush:
+	bin/magento cache:flush
+
+# Full plugin setup
+plugin: install configure flush
+
+# Setup permissions
+fs:
+	find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+	find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+	chmod 777 -R var
+	chown -R www-data:www-data .
+	chmod u+x bin/magento
+	echo "memory_limit = -1" > /usr/local/etc/php/conf.d/memory.ini
+
+MAGENTO_ROOT=/var/www/html
+GRAPHQL_XML=${MAGENTO_ROOT}/dev/tests/api-functional/phpunit_graphql.xml.dist
+GRAPHQL_PHP=/data/extensions/workdir/Test/phpunit_graphql.php
+GRAPHQL_SUITE=${MAGENTO_ROOT}/vendor/adyen/adyen-magento2-expresscheckout/Test/api-functional/GraphQl
+
+# GraphQL tests
+graphql:
+	@cd ${MAGENTO_ROOT}/dev/tests/api-functional && \
+		${MAGENTO_ROOT}/vendor/bin/phpunit --prepend ${GRAPHQL_PHP} --configuration ${GRAPHQL_XML} ${GRAPHQL_SUITE}

--- a/.github/config/php.ini
+++ b/.github/config/php.ini
@@ -1,0 +1,8 @@
+memory_limit = 2G
+; Error reporting in production mode
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+display_errors = Off
+display_startup_errors = On
+post_max_size = 20M
+upload_max_filesize = 20M
+date.timezone = Europe/Amsterdam

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3'
+
+services:
+  db:
+    image: mariadb:10.4
+    container_name: mariadb
+    networks:
+      - backend
+    environment:
+      MARIADB_ROOT_PASSWORD: root_password
+      MARIADB_DATABASE: magento
+      MARIADB_USER: magento
+      MARIADB_PASSWORD: magento
+  elastic:
+    image: elasticsearch:7.17.22
+    container_name: elasticsearch
+    networks:
+      - backend
+    ports:
+      - 9200:9200
+      - 9300:9300
+    environment:
+      - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
+  web:
+    build:
+      context: .
+      args:
+        - PHP_VERSION=${PHP_VERSION}
+        - MAGENTO_VERSION=${MAGENTO_VERSION}
+    container_name: magento2-container
+    extra_hosts:
+      - "magento2.test.com:127.0.0.1"
+    networks:
+      backend:
+        aliases:
+          - magento2.test.com
+    environment:
+      DB_SERVER: mariadb
+      ELASTICSEARCH_SERVER: elasticsearch
+      MAGENTO_HOST: magento2.test.com
+      VIRTUAL_HOST: magento2.test.com
+      COMPOSER_MEMORY_LIMIT: -1
+      DEPLOY_SAMPLEDATA:
+      ADMIN_USERNAME:
+      ADMIN_PASSWORD:
+      ADYEN_MERCHANT:
+      ADYEN_API_KEY:
+      ADYEN_CLIENT_KEY:
+      PHP_VERSION:
+      MAGENTO_VERSION:
+    depends_on:
+      - db
+      - elastic
+    volumes:
+      - ../:/data/extensions/workdir
+      - ./Makefile:/var/www/html/Makefile
+      - composer:/usr/local/bin
+      - magento:/var/www/html
+networks:
+  backend:
+volumes:
+  magento:
+  composer:

--- a/.github/scripts/install_magento.sh
+++ b/.github/scripts/install_magento.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+MAGENTO_INSTALL_ARGS="";
+
+if [ "$DB_SERVER" != "<will be defined>" ]; then
+	RET=1
+	while [ $RET -ne 0 ]; do
+		echo "Checking if $DB_SERVER is available."
+		mysql -h "$DB_SERVER" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" -e "status" >/dev/null 2>&1
+		RET=$?
+
+		if [ $RET -ne 0 ]; then
+			echo "Connection to MySQL/MariaDB is pending."
+			sleep 5
+		fi
+	done
+	echo "DB server $DB_SERVER is available."
+else
+	echo "MySQL/MariaDB server is not defined!"
+	exit 1
+fi
+
+USE_ELASTICSEARCH='1'
+if [[ "$MAGENTO_VERSION" =~ ^2\.3 ]]; then
+	USE_ELASTICSEARCH='0'
+fi
+
+if [ "$USE_ELASTICSEARCH" == '1' ] && [ "$ELASTICSEARCH_SERVER" != "<will be defined>" ]; then
+	MAGENTO_INSTALL_ARGS=$(echo \
+		--elasticsearch-host="$ELASTICSEARCH_SERVER" \
+		--elasticsearch-port="$ELASTICSEARCH_PORT" \
+		--elasticsearch-index-prefix="$ELASTICSEARCH_INDEX_PREFIX" \
+		--elasticsearch-timeout="$ELASTICSEARCH_TIMEOUT")
+	RET=1
+	while [ $RET -ne 0 ]; do
+		echo "Checking if $ELASTICSEARCH_SERVER is available."
+		curl -XGET "$ELASTICSEARCH_SERVER:$ELASTICSEARCH_PORT/_cat/health?v&pretty" >/dev/null 2>&1
+		RET=$?
+
+		if [ $RET -ne 0 ]; then
+			echo "Connection to Elasticsearch is pending."
+			sleep 5
+		fi
+	done
+	echo "Elasticsearch server $ELASTICSEARCH_SERVER is available."
+fi
+
+if [[ -e /tmp/magento.tar.gz ]]; then
+	mv /tmp/magento.tar.gz /var/www/html
+else
+	echo "Magento 2 tar is already moved to /var/www/html"
+fi
+
+if [[ -e /tmp/sample-data.tar.gz ]]; then
+	mv /tmp/sample-data.tar.gz /var/www
+else
+	echo "Magento 2 sample data tar is alread moved to /var/www"
+fi
+
+if [[ -e /var/www/html/pub/index.php ]]; then
+	echo "Already extracted Magento"
+else
+	tar -xf magento.tar.gz --strip-components 1
+	rm magento.tar.gz
+fi
+
+if [[ -e /usr/local/bin/composer ]]; then
+	echo "Composer already exists"
+else
+	php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+	php composer-setup.php --quiet
+	rm composer-setup.php
+	mv composer.phar /usr/local/bin/composer
+fi
+
+if [[ -d /var/www/html/vendor/magento ]]; then
+	echo "Magento is already installed."
+else
+	composer install -n
+
+	find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+	find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+	chown -R www-data:www-data .
+	chmod u+x bin/magento
+
+	bin/magento setup:install \
+		--base-url="http://$MAGENTO_HOST" \
+		--db-host="$DB_SERVER:$DB_PORT" \
+		--db-name="$DB_NAME" \
+		--db-user="$DB_USER" \
+		--db-password="$DB_PASSWORD" \
+		--db-prefix="$DB_PREFIX" \
+		--admin-firstname="$ADMIN_NAME" \
+		--admin-lastname="$ADMIN_LASTNAME" \
+		--admin-email="$ADMIN_EMAIL" \
+		--admin-user="$ADMIN_USERNAME" \
+		--admin-password="$ADMIN_PASSWORD" \
+		--backend-frontname="$ADMIN_URLEXT" \
+		--language=en_US \
+		--currency=EUR \
+		--timezone=Europe/Amsterdam \
+		--use-rewrites=1 \
+		--cleanup-database \
+		$MAGENTO_INSTALL_ARGS;
+
+	bin/magento setup:di:compile
+	bin/magento setup:static-content:deploy -f
+	bin/magento indexer:reindex
+	bin/magento deploy:mode:set developer
+	bin/magento maintenance:disable
+	bin/magento cron:install
+
+	echo "Installation completed"
+fi
+
+if [ "$DEPLOY_SAMPLEDATA" -eq 1 ]; then
+	if [[ -e ../sample-data.tar.gz ]]; then
+		echo "Installing sample data"
+		mkdir ../sample-data
+		tar -xf ../sample-data.tar.gz --strip-components 1 -C ../sample-data
+		rm ../sample-data.tar.gz
+		php -f ../sample-data/dev/tools/build-sample-data.php -- --ce-source="/var/www/html"
+		bin/magento setup:upgrade
+	else
+		echo "Sample data is already installed"
+	fi
+fi
+
+ISSET_USE_SSL=$(bin/magento config:show web/secure/use_in_frontend)
+
+if [ "$USE_SSL" -eq 1 ]; then
+	if [ "${ISSET_USE_SSL:-0}" -eq 1 ]; then
+		echo "Use SSL is set, but SSL is already enabled."
+	else
+		bin/magento setup:store-config:set \
+			--base-url-secure="https://$MAGENTO_HOST" \
+			--use-secure=1 \
+			--use-secure-admin=1
+		echo "SSL for Magento is configured."
+	fi
+else
+	echo "Use SSL is not set, skipping."
+fi
+
+grep "ServerName" /etc/apache2/apache2.conf >/dev/null 2>&1
+SERVERNAME_EXISTS=$?
+
+if [ $SERVERNAME_EXISTS -eq 0 ]; then
+	echo "ServerName is already added in Apache config."
+else
+	echo "ServerName $MAGENTO_HOST" >>/etc/apache2/apache2.conf
+	echo "ServerName is added to Apache config."
+fi
+
+if [[ -e /tmp/enable_debugging.sh ]]; then
+	echo "Configuring Xdebug"
+	/tmp/enable_debugging.sh
+fi
+
+/etc/init.d/cron start
+
+exec apache2-foreground

--- a/.github/workflows/graphql-test.yml
+++ b/.github/workflows/graphql-test.yml
@@ -1,0 +1,43 @@
+name: GraphQL Tests
+on:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        php-version: ["8.1"]
+        magento-version: ["2.4.5"]
+    runs-on: ubuntu-latest
+    env:
+      PHP_VERSION: ${{ matrix.php-version }}
+      MAGENTO_VERSION: ${{ matrix.magento-version }}
+      ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
+      ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
+      ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
+      ADYEN_API_KEY: ${{secrets.ADYEN_API_KEY}}
+      ADYEN_CLIENT_KEY: ${{secrets.ADYEN_CLIENT_KEY}}
+      DEPLOY_SAMPLEDATA: 1
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Magento
+        run: docker compose -f .github/docker-compose.yml run --rm web make magento
+
+      - name: Start web server in background
+        run: docker compose -f .github/docker-compose.yml up -d web
+
+      - name: Setup permissions
+        run: docker exec magento2-container make fs
+
+      - name: Check install
+        run: docker exec magento2-container make sys-check
+
+      - name: Install plugin
+        run: docker exec -u www-data magento2-container make plugin
+
+      - run: docker exec magento2-container /etc/init.d/cron stop
+
+      - name: Run GraphQL tests
+        run: docker exec magento2-container make graphql

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,28 +1,49 @@
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
 name: Main Workflow
 
 jobs:
-  run:
-    name: Run
+  build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php-version: [ 7.4, 8.0, 8.1 ]
+        php-version: [8.2,8.3]
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer:v1
+          tools: composer:v2
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Test plugin installation
+        run: |
+          echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json
+          composer install --prefer-dist
+        env:
+          CI: true
+          MAGENTO_USERNAME: ${{ secrets.MAGENTO_USERNAME }}
+          MAGENTO_PASSWORD: ${{ secrets.MAGENTO_PASSWORD }}
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --coverage-clover=build/clover.xml --log-junit=build/tests-log.xml -c Test/phpunit.xml Test/Unit
+
+      - name: Fix code coverage paths
+        run: sed -i "s;`pwd`/;;g" build/*.xml
+
+      - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN }}
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: TruffleHog OSS
         uses: trufflesecurity/trufflehog@main

--- a/Model/Resolver/ExpressActivateResolver.php
+++ b/Model/Resolver/ExpressActivateResolver.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressActivate;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class ExpressActivateResolver implements ResolverInterface
+{
+    public function __construct(
+        public ExpressActivate $expressActivateApi,
+        public ValueFactory $valueFactory
+    ) { }
+
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['adyenMaskedQuoteId'])) {
+            throw new GraphQlInputException(__('Required parameter "adyenMaskedQuoteId" is missing!'));
+        }
+
+        $adyenMaskedQuoteId = $args['adyenMaskedQuoteId'];
+        $adyenCartId = $args['adyenCartId'] ?? null;
+
+        $provider = $this->expressActivateApi;
+
+        $result = function () use ($adyenMaskedQuoteId, $adyenCartId, $provider) {
+            $provider->execute($adyenMaskedQuoteId, $adyenCartId);
+            return true;
+        };
+
+        return $this->valueFactory->create($result);
+    }
+}

--- a/Model/Resolver/ExpressActivateResolver.php
+++ b/Model/Resolver/ExpressActivateResolver.php
@@ -14,35 +14,76 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Model\Resolver;
 
 use Adyen\ExpressCheckout\Model\ExpressActivate;
+use Adyen\Payment\Logger\AdyenLogger;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\QuoteIdMaskFactory;
 
 class ExpressActivateResolver implements ResolverInterface
 {
+    /**
+     * @param ExpressActivate $expressActivateApi
+     * @param ValueFactory $valueFactory
+     * @param QuoteIdMaskFactory $quoteMaskFactory
+     * @param AdyenLogger $adyenLogger
+     */
     public function __construct(
         public ExpressActivate $expressActivateApi,
-        public ValueFactory $valueFactory
+        public ValueFactory $valueFactory,
+        public QuoteIdMaskFactory $quoteMaskFactory,
+        public AdyenLogger $adyenLogger
     ) { }
 
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    /**
+     * @param Field $field
+     * @param $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return Value
+     * @throws GraphQlInputException
+     * @throws LocalizedException
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): Value
     {
         if (empty($args['adyenMaskedQuoteId'])) {
             throw new GraphQlInputException(__('Required parameter "adyenMaskedQuoteId" is missing!'));
         }
 
-        $adyenMaskedQuoteId = $args['adyenMaskedQuoteId'];
-        $adyenCartId = $args['adyenCartId'] ?? null;
+        try {
+            $adyenMaskedQuoteId = $args['adyenMaskedQuoteId'];
+            $adyenCartId = $args['adyenCartId'] ?? null;
 
-        $provider = $this->expressActivateApi;
+            if (isset($adyenCartId)) {
+                $quoteIdMask = $this->quoteMaskFactory->create()->load(
+                    $adyenCartId,
+                    'masked_id'
+                );
+                $quoteId = (int) $quoteIdMask->getQuoteId();
+            } else {
+                $quoteId = null;
+            }
 
-        $result = function () use ($adyenMaskedQuoteId, $adyenCartId, $provider) {
-            $provider->execute($adyenMaskedQuoteId, $adyenCartId);
-            return true;
-        };
+            $provider = $this->expressActivateApi;
 
-        return $this->valueFactory->create($result);
+            $result = function () use ($adyenMaskedQuoteId, $quoteId, $provider) {
+                $provider->execute($adyenMaskedQuoteId, $quoteId);
+                return true;
+            };
+
+            return $this->valueFactory->create($result);
+        } catch (Exception $e) {
+            $errorMessage = "An error occurred while activating the express quote";
+            $logMessage = sprintf("%s: %s", $errorMessage, $e->getMessage());
+            $this->adyenLogger->error($logMessage);
+
+            throw new LocalizedException(__($errorMessage));
+        }
     }
 }

--- a/Model/Resolver/ExpressCancelResolver.php
+++ b/Model/Resolver/ExpressCancelResolver.php
@@ -17,10 +17,8 @@ use Adyen\ExpressCheckout\Model\ExpressCancel;
 use Adyen\Payment\Logger\AdyenLogger;
 use Exception;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
-use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
@@ -48,12 +46,11 @@ class ExpressCancelResolver implements ResolverInterface
      * @param ResolveInfo $info
      * @param array|null $value
      * @param array|null $args
-     * @return Value|mixed
+     * @return Value
      * @throws GraphQlInputException
-     * @throws GraphQlNoSuchEntityException
      * @throws LocalizedException
      */
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): Value
     {
         if (empty($args['adyenCartId'])) {
             throw new GraphQlInputException(__('Required parameter "adyenCartId" is missing!'));
@@ -76,8 +73,6 @@ class ExpressCancelResolver implements ResolverInterface
             };
 
             return $this->valueFactory->create($result);
-        } catch (NoSuchEntityException $e) {
-            throw new GraphQlNoSuchEntityException(__($e->getMessage()));
         } catch (Exception $e) {
             $errorMessage = "An error occurred while cancelling the express quote";
             $logMessage = sprintf("%s: %s", $errorMessage, $e->getMessage());

--- a/Model/Resolver/ExpressCancelResolver.php
+++ b/Model/Resolver/ExpressCancelResolver.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressCancel;
+use Adyen\Payment\Logger\AdyenLogger;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+
+class ExpressCancelResolver implements ResolverInterface
+{
+    /**
+     * @param ExpressCancel $expressCancelApi
+     * @param ValueFactory $valueFactory
+     * @param QuoteIdMaskFactory $quoteMaskFactory
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        public ExpressCancel $expressCancelApi,
+        public ValueFactory $valueFactory,
+        public QuoteIdMaskFactory $quoteMaskFactory,
+        public AdyenLogger $adyenLogger
+    ) { }
+
+    /**
+     * @param Field $field
+     * @param $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return Value|mixed
+     * @throws GraphQlInputException
+     * @throws GraphQlNoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['adyenCartId'])) {
+            throw new GraphQlInputException(__('Required parameter "adyenCartId" is missing!'));
+        }
+
+        try {
+            // Extract unmasked quote id
+            $adyenCartId = $args['adyenCartId'];
+            $quoteIdMask = $this->quoteMaskFactory->create()->load(
+                $adyenCartId,
+                'masked_id'
+            );
+            $quoteId = (int) $quoteIdMask->getQuoteId();
+
+            $provider = $this->expressCancelApi;
+
+            $result = function () use ($quoteId, $provider) {
+                $provider->execute($quoteId);
+                return true;
+            };
+
+            return $this->valueFactory->create($result);
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(__($e->getMessage()));
+        } catch (Exception $e) {
+            $errorMessage = "An error occurred while cancelling the express quote";
+            $logMessage = sprintf("%s: %s", $errorMessage, $e->getMessage());
+            $this->adyenLogger->error($logMessage);
+
+            throw new LocalizedException(__($errorMessage));
+        }
+    }
+}

--- a/Model/Resolver/ExpressCancelResolver.php
+++ b/Model/Resolver/ExpressCancelResolver.php
@@ -52,15 +52,15 @@ class ExpressCancelResolver implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): Value
     {
-        if (empty($args['adyenCartId'])) {
-            throw new GraphQlInputException(__('Required parameter "adyenCartId" is missing!'));
+        if (empty($args['adyenMaskedQuoteId'])) {
+            throw new GraphQlInputException(__('Required parameter "adyenMaskedQuoteId" is missing!'));
         }
 
         try {
             // Extract unmasked quote id
-            $adyenCartId = $args['adyenCartId'];
+            $adyenMaskedQuoteId = $args['adyenMaskedQuoteId'];
             $quoteIdMask = $this->quoteMaskFactory->create()->load(
-                $adyenCartId,
+                $adyenMaskedQuoteId,
                 'masked_id'
             );
             $quoteId = (int) $quoteIdMask->getQuoteId();

--- a/Model/Resolver/ExpressInitResolver.php
+++ b/Model/Resolver/ExpressInitResolver.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Model\Resolver;
+
+use Adyen\ExpressCheckout\Api\Data\ProductCartParamsInterfaceFactory;
+use Adyen\ExpressCheckout\Model\ExpressInit;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class ExpressInitResolver implements ResolverInterface
+{
+    /**
+     * @param ExpressInit $expressInitApi
+     * @param ProductCartParamsInterfaceFactory $productCartParamsFactory
+     * @param ValueFactory $valueFactory
+     */
+    public function __construct(
+        public ExpressInit $expressInitApi,
+        public ProductCartParamsInterfaceFactory $productCartParamsFactory,
+        public ValueFactory $valueFactory
+    ) { }
+
+    /**
+     * @param Field $field
+     * @param $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return Value
+     * @throws GraphQlInputException
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): Value
+    {
+        if (empty($args['productCartParams'])) {
+            throw new GraphQlInputException(__('Required parameter "productCartParams" is missing!'));
+        }
+
+        $productCartParamsDecoded = json_decode($args['productCartParams'], true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new GraphQlInputException(__('Invalid JSON provided for "productCartParams"!'));
+        }
+
+        $productCartParams = $this->productCartParamsFactory->create();
+        $productCartParams->setData($productCartParamsDecoded);
+
+        $adyenCartId = $args['adyenCartId'] ?? null;
+        $adyenMaskedQuoteId = $args['adyenMaskedQuoteId'] ?? null;
+        $provider = $this->expressInitApi;
+
+        $result = function () use ($productCartParams, $adyenCartId, $adyenMaskedQuoteId, $provider) {
+            return $provider->execute($productCartParams, $adyenCartId, $adyenMaskedQuoteId);
+        };
+
+        return $this->valueFactory->create($result);
+    }
+}

--- a/Test/Unit/Model/Resolver/ExpressActivateResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressActivateResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressActivate;
+use Adyen\ExpressCheckout\Model\Resolver\ExpressActivateResolver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Exception;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\Context;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ExpressActivateResolverTest extends AbstractAdyenTestCase
+{
+    // Mocks for class builder
+    protected ?ExpressActivateResolver $expressActivateResolver;
+    protected MockObject&ExpressActivate $expressActivateMock;
+    protected MockObject&ValueFactory $valueFactoryMock;
+
+    // Mocks for `resolve()` method
+    protected MockObject&Field $fieldMock;
+    protected MockObject&Context $contextMock;
+    protected MockObject&ResolveInfo $infoMock;
+
+    public function setUp(): void
+    {
+        $this->expressActivateMock = $this->createMock(ExpressActivate::class);
+
+        $this->valueFactoryMock = $this->createMock(ValueFactory::class);
+        $this->fieldMock = $this->createMock(Field::class);
+        $this->contextMock = $this->createMock(Context::class);
+        $this->infoMock = $this->createMock(ResolveInfo::class);
+
+        $this->expressActivateResolver = new ExpressActivateResolver(
+            $this->expressActivateMock,
+            $this->valueFactoryMock
+        );
+    }
+
+    /**
+     * Reset the target class after each test
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->expressActivateResolver = null;
+    }
+
+    /**
+     * Assets expect exception if the required parameter `adyenMaskedQuoteId` is an empty string.
+     *
+     * @return void
+     * @throws GraphQlInputException|Exception
+     */
+    public function testResolverShouldThrowExceptionWithEmptyArgument()
+    {
+        $this->expectException(GraphQlInputException::class);
+
+        $args = [
+            'adyenMaskedQuoteId' => ""
+        ];
+
+        $this->expressActivateResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets successful generation of the Value class after resolving
+     * the mutation with correct set of inputs.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulResolving()
+    {
+        $args['adyenMaskedQuoteId'] = "Mock_adyenMaskedQuoteId";
+
+        $returnValueMock = $this->createMock(Value::class);
+        $this->valueFactoryMock->method('create')->willReturn($returnValueMock);
+
+        $result = $this->expressActivateResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+
+        $this->assertInstanceOf(Value::class, $result);
+    }
+}

--- a/Test/Unit/Model/Resolver/ExpressActivateResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressActivateResolverTest.php
@@ -11,16 +11,21 @@
 
 namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
 
+use Adyen\ExpressCheckout\Exception\ExpressInitException;
 use Adyen\ExpressCheckout\Model\ExpressActivate;
 use Adyen\ExpressCheckout\Model\Resolver\ExpressActivateResolver;
+use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Exception;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\GraphQl\Model\Query\Context;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ExpressActivateResolverTest extends AbstractAdyenTestCase
@@ -29,6 +34,8 @@ class ExpressActivateResolverTest extends AbstractAdyenTestCase
     protected ?ExpressActivateResolver $expressActivateResolver;
     protected MockObject&ExpressActivate $expressActivateMock;
     protected MockObject&ValueFactory $valueFactoryMock;
+    protected MockObject&QuoteIdMaskFactory $quoteIdMaskFactoryMock;
+    protected MockObject&AdyenLogger $loggerMock;
 
     // Mocks for `resolve()` method
     protected MockObject&Field $fieldMock;
@@ -43,10 +50,16 @@ class ExpressActivateResolverTest extends AbstractAdyenTestCase
         $this->fieldMock = $this->createMock(Field::class);
         $this->contextMock = $this->createMock(Context::class);
         $this->infoMock = $this->createMock(ResolveInfo::class);
+        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(QuoteIdMaskFactory::class, [
+            'create'
+        ]);
+        $this->loggerMock = $this->createMock(AdyenLogger::class);
 
         $this->expressActivateResolver = new ExpressActivateResolver(
             $this->expressActivateMock,
-            $this->valueFactoryMock
+            $this->valueFactoryMock,
+            $this->quoteIdMaskFactoryMock,
+            $this->loggerMock
         );
     }
 
@@ -83,19 +96,50 @@ class ExpressActivateResolverTest extends AbstractAdyenTestCase
         );
     }
 
+    public static function successfulResolverDataProvider(): array
+    {
+        return [
+            [
+                'args' => [
+                    'adyenMaskedQuoteId' => 'mock_adyen_masked_quote_id',
+                    'adyenCartId' => 'mock_adyen_cart_id'
+                ]
+            ],
+            [
+                'args' => [
+                    'adyenMaskedQuoteId' => 'mock_adyen_masked_quote_id',
+                    'adyenCartId' => null
+                ]
+            ],
+            [
+                'args' => [
+                    'adyenMaskedQuoteId' => 'mock_adyen_masked_quote_id'
+                ]
+            ]
+        ];
+    }
+
     /**
      * Assets successful generation of the Value class after resolving
      * the mutation with correct set of inputs.
      *
+     * @dataProvider successfulResolverDataProvider
+     *
      * @return void
      * @throws Exception
      */
-    public function testSuccessfulResolving()
+    public function testSuccessfulResolving($args)
     {
-        $args['adyenMaskedQuoteId'] = "Mock_adyenMaskedQuoteId";
-
         $returnValueMock = $this->createMock(Value::class);
         $this->valueFactoryMock->method('create')->willReturn($returnValueMock);
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+        $this->quoteIdMaskFactoryMock->method('create')->willReturn($quoteIdMaskMock);
 
         $result = $this->expressActivateResolver->resolve(
             $this->fieldMock,
@@ -106,5 +150,34 @@ class ExpressActivateResolverTest extends AbstractAdyenTestCase
         );
 
         $this->assertInstanceOf(Value::class, $result);
+    }
+
+    /**
+     * Asserts exception if the quote entity not found
+     *
+     * @return void
+     * @throws GraphQlInputException
+     * @throws LocalizedException
+     */
+    public function testMissingQuoteShouldThrowException()
+    {
+        $this->expectException(LocalizedException::class);
+
+        $args = [
+            'adyenMaskedQuoteId' => 'mock_product_cart_params'
+        ];
+
+        $this->valueFactoryMock->method('create')
+            ->willThrowException(new ExpressInitException(__('Localized test exception!')));
+
+        $this->expressActivateResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+
+        $this->loggerMock->expects($this->once())->method('error');
     }
 }

--- a/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
@@ -98,41 +98,6 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
     }
 
     /**
-     * Assets expect exception if the masked quote id doesn't belong to any quote
-     *
-     * @return void
-     * @throws Exception
-     */
-    public function testResolverShouldThrowExceptionNonExistingQuote()
-    {
-        $this->expectException(GraphQlNoSuchEntityException::class);
-
-        $args = [
-            'adyenCartId' => "Mock_adyen_cart_id"
-        ];
-
-        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
-            'load',
-            'getQuoteId'
-        ]);
-        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
-        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
-
-        $this->quoteIdMaskFactoryMock->method('create')
-            ->willReturn($quoteIdMaskMock);
-
-        $this->valueFactoryMock->method('create')->willThrowException(new NoSuchEntityException());
-
-        $this->expressCancelResolver->resolve(
-            $this->fieldMock,
-            $this->contextMock,
-            $this->infoMock,
-            [],
-            $args
-        );
-    }
-
-    /**
      * Assets expect exception if the quote id can not be unmasked
      *
      * @return void

--- a/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
@@ -17,10 +17,8 @@ use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Exception;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
-use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
@@ -42,7 +40,6 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
     protected MockObject&Field $fieldMock;
     protected MockObject&Context $contextMock;
     protected MockObject&ResolveInfo $infoMock;
-
 
     public function setUp(): void
     {
@@ -75,7 +72,7 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
     }
 
     /**
-     * Assets expect exception if the required parameter `adyenCartId` is an empty string.
+     * Assets expect exception if the required parameter `adyenMaskedQuoteId` is an empty string.
      *
      * @return void
      * @throws GraphQlInputException|Exception
@@ -85,7 +82,7 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
         $this->expectException(GraphQlInputException::class);
 
         $args = [
-            'adyenCartId' => ""
+            'adyenMaskedQuoteId' => ""
         ];
 
         $this->expressCancelResolver->resolve(
@@ -108,7 +105,7 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
         $this->expectException(LocalizedException::class);
 
         $args = [
-            'adyenCartId' => "Mock_adyen_cart_id"
+            'adyenMaskedQuoteId' => "mock_adyen_masked_quote_id"
         ];
 
         $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
@@ -139,7 +136,7 @@ class ExpressCancelResolverTest extends AbstractAdyenTestCase
      */
     public function testSuccessfulResolving()
     {
-        $args['adyenCartId'] = "Mock_adyenCartId";
+        $args['adyenMaskedQuoteId'] = "mock_adyen_masked_quote_id";
 
         $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
             'load',

--- a/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressCancelResolverTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
+
+use Adyen\ExpressCheckout\Model\ExpressCancel;
+use Adyen\ExpressCheckout\Model\Resolver\ExpressCancelResolver;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\Context;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ExpressCancelResolverTest extends AbstractAdyenTestCase
+{
+    // Mocks for class builder
+    protected ?ExpressCancelResolver $expressCancelResolver;
+    protected MockObject&ExpressCancel $expressCancelMock;
+    protected MockObject&ValueFactory $valueFactoryMock;
+    protected MockObject&QuoteIdMaskFactory $quoteIdMaskFactoryMock;
+    protected MockObject&AdyenLogger $loggerMock;
+
+    // Mocks for `resolve()` method
+    protected MockObject&Field $fieldMock;
+    protected MockObject&Context $contextMock;
+    protected MockObject&ResolveInfo $infoMock;
+
+
+    public function setUp(): void
+    {
+        $this->expressCancelMock = $this->createMock(ExpressCancel::class);
+        $this->valueFactoryMock = $this->createMock(ValueFactory::class);
+        $this->fieldMock = $this->createMock(Field::class);
+        $this->contextMock = $this->createMock(Context::class);
+        $this->infoMock = $this->createMock(ResolveInfo::class);
+        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(QuoteIdMaskFactory::class, [
+            'create'
+        ]);
+        $this->loggerMock = $this->createMock(AdyenLogger::class);
+
+        $this->expressCancelResolver = new ExpressCancelResolver(
+            $this->expressCancelMock,
+            $this->valueFactoryMock,
+            $this->quoteIdMaskFactoryMock,
+            $this->loggerMock
+        );
+    }
+
+    /**
+     * Reset the target class after each test
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->expressCancelResolver = null;
+    }
+
+    /**
+     * Assets expect exception if the required parameter `adyenCartId` is an empty string.
+     *
+     * @return void
+     * @throws GraphQlInputException|Exception
+     */
+    public function testResolverShouldThrowExceptionWithEmptyArgument()
+    {
+        $this->expectException(GraphQlInputException::class);
+
+        $args = [
+            'adyenCartId' => ""
+        ];
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets expect exception if the masked quote id doesn't belong to any quote
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResolverShouldThrowExceptionNonExistingQuote()
+    {
+        $this->expectException(GraphQlNoSuchEntityException::class);
+
+        $args = [
+            'adyenCartId' => "Mock_adyen_cart_id"
+        ];
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $this->valueFactoryMock->method('create')->willThrowException(new NoSuchEntityException());
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets expect exception if the quote id can not be unmasked
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResolverShouldThrowExceptionInvalidQuoteId()
+    {
+        $this->expectException(LocalizedException::class);
+
+        $args = [
+            'adyenCartId' => "Mock_adyen_cart_id"
+        ];
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willThrowException(new Exception());
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Assets successful generation of the Value class after resolving
+     * the mutation with correct set of inputs.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulResolving()
+    {
+        $args['adyenCartId'] = "Mock_adyenCartId";
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, [
+            'load',
+            'getQuoteId'
+        ]);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+
+        $this->quoteIdMaskFactoryMock->method('create')
+            ->willReturn($quoteIdMaskMock);
+
+        $returnValueMock = $this->createMock(Value::class);
+        $this->valueFactoryMock->method('create')->willReturn($returnValueMock);
+
+        $result = $this->expressCancelResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+
+        $this->assertInstanceOf(Value::class, $result);
+    }
+}

--- a/Test/Unit/Model/Resolver/ExpressInitResolverTest.php
+++ b/Test/Unit/Model/Resolver/ExpressInitResolverTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
+
+use Adyen\ExpressCheckout\Api\Data\ProductCartParamsInterfaceFactory;
+use Adyen\ExpressCheckout\Model\ExpressInit;
+use Adyen\ExpressCheckout\Model\ProductCartParams;
+use Adyen\ExpressCheckout\Model\Resolver\ExpressInitResolver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\Context;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ExpressInitResolverTest extends AbstractAdyenTestCase
+{
+    // Mocks for class builder
+    protected ?ExpressInitResolver $expressInitResolver;
+    protected MockObject&ExpressInit $expressInitMock;
+    protected MockObject&ProductCartParamsInterfaceFactory $cartParamsInterfaceFactoryMock;
+    protected MockObject&ValueFactory $valueFactoryMock;
+
+    // Mocks for `resolve()` method
+    protected MockObject&Field $fieldMock;
+    protected MockObject&Context $contextMock;
+    protected MockObject&ResolveInfo $infoMock;
+
+    const SUCCESSFUL_CART_PARAMS = "{\"product\":1562,\"qty\":\"5\",\"super_attribute\":{\"93\":56,\"144\":166}}";
+
+    public function setUp(): void
+    {
+        $this->expressInitMock = $this->createMock(ExpressInit::class);
+        $this->cartParamsInterfaceFactoryMock = $this->createGeneratedMock(
+            ProductCartParamsInterfaceFactory::class,
+            ['create']
+        );
+        $this->valueFactoryMock = $this->createMock(ValueFactory::class);
+        $this->fieldMock = $this->createMock(Field::class);
+        $this->contextMock = $this->createMock(Context::class);
+        $this->infoMock = $this->createMock(ResolveInfo::class);
+
+        $this->expressInitResolver = new ExpressInitResolver(
+            $this->expressInitMock,
+            $this->cartParamsInterfaceFactoryMock,
+            $this->valueFactoryMock
+        );
+    }
+
+    /**
+     * Reset the target class after each test
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->expressInitResolver = null;
+    }
+
+    /**
+     * Data provider for case testProductCartParamsShouldThrowException
+     *
+     * @return array[]
+     */
+    public static function invalidProductCartParamsDataProvider(): array
+    {
+        return [
+            // Simulate empty string for input field `productCartParams` and expect `GraphQlInputException`
+            ['productCartParams' => ''],
+            // Simulate invalid JSON object for input field `productCartParams` and expect `GraphQlInputException`
+            ['productCartParams' => '{\"product\":1562,\"qty\":\"5\",\"super_att.._invalidJSON']
+        ];
+    }
+
+    /**
+     * See the data provider for test case explanations.
+     *
+     * @dataProvider invalidProductCartParamsDataProvider
+     *
+     * @return void
+     * @throws GraphQlInputException
+     */
+    public function testProductCartParamsShouldThrowException($productCartParams)
+    {
+        $this->expectException(GraphQlInputException::class);
+
+        $args = [
+            'productCartParams' => $productCartParams
+        ];
+
+        $this->expressInitResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+    }
+
+    /**
+     * Data provider for case testSuccessfulResolving
+     *
+     * @return array[]
+     */
+    public static function validInputArgumentsForSuccessTest(): array
+    {
+        return [
+            [
+                'args' => [
+                    'productCartParams' => self::SUCCESSFUL_CART_PARAMS,
+                    'adyenCartId' => 'Mock_adyenCartId',
+                    'adyenMaskedQuoteId' => 'Mock_adyenMaskedQuoteId'
+                ]
+            ],
+            [
+                'args' => [
+                    'productCartParams' => self::SUCCESSFUL_CART_PARAMS,
+                    'adyenCartId' => null,
+                    'adyenMaskedQuoteId' => null
+                ]
+            ],
+            [
+                'args' => [
+                    'productCartParams' => self::SUCCESSFUL_CART_PARAMS,
+                    'adyenCartId' => "",
+                    'adyenMaskedQuoteId' => ""
+                ]
+            ],
+            [
+                'args' => [
+                    'productCartParams' => self::SUCCESSFUL_CART_PARAMS
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Assets successful generation of the Value class after resolving
+     * the mutation with different set of inputs.
+     *
+     * @dataProvider validInputArgumentsForSuccessTest
+     *
+     * @return void
+     * @throws GraphQlInputException
+     */
+    public function testSuccessfulResolving($args)
+    {
+        $productCartParamsMock = $this->createMock(ProductCartParams::class);
+        $this->cartParamsInterfaceFactoryMock->method('create')->willReturn($productCartParamsMock);
+
+        $returnValueMock = $this->createMock(Value::class);
+        $this->valueFactoryMock->method('create')->willReturn($returnValueMock);
+
+        $result = $this->expressInitResolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->infoMock,
+            [],
+            $args
+        );
+
+        $this->assertInstanceOf(Value::class, $result);
+    }
+}

--- a/Test/api-functional/GraphQl/AdyenExpressTest.php
+++ b/Test/api-functional/GraphQl/AdyenExpressTest.php
@@ -147,4 +147,41 @@ QUERY;
         $this->assertArrayHasKey('expressActivate', $response);
         $this->assertTrue($response['expressActivate']);
     }
+
+    /**
+     * Test case for expressCancel mutation with valid adyenCartId
+     * should activate the quote and return TRUE.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulExpressQuoteCancellation(): void
+    {
+        // Generate express quote for PDP
+        $query = <<<QUERY
+mutation {
+    expressInit(
+        productCartParams: "{\"product\":1562,\"qty\":\"1\",\"super_attribute\":{\"93\":56,\"144\":166}}"
+    ) {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $initiateQuote = $this->graphQlMutation($query);
+        $expressMaskedQuoteId = $initiateQuote['expressInit']['masked_quote_id'];
+
+        $query = <<<QUERY
+mutation {
+    expressCancel(
+        adyenCartId: "$expressMaskedQuoteId"
+    )
+}
+QUERY;
+
+        $response = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressCancel', $response);
+        $this->assertTrue($response['expressCancel']);
+    }
 }

--- a/Test/api-functional/GraphQl/AdyenExpressTest.php
+++ b/Test/api-functional/GraphQl/AdyenExpressTest.php
@@ -111,4 +111,40 @@ QUERY;
         $this->assertArrayHasKey('masked_quote_id', $updateCallResponse['expressInit']);
         $this->assertEquals($maskedQuoteId, $updateCallResponse['expressInit']['masked_quote_id']);
     }
+
+    /**
+     * Test case for expressActivate mutation with valid adyenMaskedQuoteId
+     * should activate the quote and return TRUE.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulExpressQuoteActivation(): void
+    {
+        $query = <<<QUERY
+mutation {
+    expressInit(
+        productCartParams: "{\"product\":1562,\"qty\":\"1\",\"super_attribute\":{\"93\":56,\"144\":166}}"
+    ) {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $initiateQuote = $this->graphQlMutation($query);
+        $maskedQuoteId = $initiateQuote['expressInit']['masked_quote_id'];
+
+        $query = <<<QUERY
+mutation {
+    expressActivate(
+        adyenMaskedQuoteId: "$maskedQuoteId"
+    )
+}
+QUERY;
+
+        $response = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressActivate', $response);
+        $this->assertTrue($response['expressActivate']);
+    }
 }

--- a/Test/api-functional/GraphQl/AdyenExpressTest.php
+++ b/Test/api-functional/GraphQl/AdyenExpressTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\GraphQl;
+
+use Exception;
+use Magento\TestFramework\TestCase\GraphQl\ResponseContainsErrorsException;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+class AdyenExpressTest extends GraphQlAbstract
+{
+    /**
+     * Test case for expressInit mutation should throw an exception
+     * with an empty `productCartParams` input field.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testEmptyCartParamsShouldThrowException(): void
+    {
+        $query = <<<QUERY
+mutation {
+    expressInit(productCartParams: "") {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $this->expectException(ResponseContainsErrorsException::class);
+        $this->graphQlMutation($query);
+    }
+
+    /**
+     * Test case for expressInit mutation with valid productCartParams
+     * should generate a valid quote and return `masked_quote_id`.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulQuoteInitiation(): void
+    {
+        $query = <<<QUERY
+mutation {
+    expressInit(productCartParams: "{\"product\":1562,\"qty\":\"5\",\"super_attribute\":{\"93\":56,\"144\":166}}") {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $response = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressInit', $response);
+        $this->assertArrayHasKey('masked_quote_id', $response['expressInit']);
+    }
+
+    /**
+     * Test case for expressInit mutation with valid productCartParams
+     * should update the quote and return the updated quote with the same masked_quote_id.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testSuccessfulQuoteUpdate(): void
+    {
+        $query = <<<QUERY
+mutation {
+    expressInit(
+        productCartParams: "{\"product\":1562,\"qty\":\"1\",\"super_attribute\":{\"93\":56,\"144\":166}}"
+    ) {
+        masked_quote_id
+    }
+}
+QUERY;
+
+        $initialResponse = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressInit', $initialResponse);
+        $this->assertArrayHasKey('masked_quote_id', $initialResponse['expressInit']);
+
+        $maskedQuoteId = $initialResponse['expressInit']['masked_quote_id'];
+
+        $query = <<<QUERY
+mutation {
+    expressInit(
+        productCartParams: "{\"product\":1562,\"qty\":\"5\",\"super_attribute\":{\"93\":56,\"144\":166}}",
+        adyenMaskedQuoteId: "$maskedQuoteId"
+    ) {
+        masked_quote_id
+        totals {
+            items_qty
+        }
+    }
+}
+QUERY;
+
+        $updateCallResponse = $this->graphQlMutation($query);
+
+        $this->assertArrayHasKey('expressInit', $updateCallResponse);
+        $this->assertArrayHasKey('totals', $updateCallResponse['expressInit']);
+        $this->assertArrayHasKey('items_qty', $updateCallResponse['expressInit']['totals']);
+        $this->assertEquals('5', $updateCallResponse['expressInit']['totals']['items_qty']);
+        $this->assertArrayHasKey('masked_quote_id', $updateCallResponse['expressInit']);
+        $this->assertEquals($maskedQuoteId, $updateCallResponse['expressInit']['masked_quote_id']);
+    }
+}

--- a/Test/api-functional/GraphQl/AdyenExpressTest.php
+++ b/Test/api-functional/GraphQl/AdyenExpressTest.php
@@ -174,7 +174,7 @@ QUERY;
         $query = <<<QUERY
 mutation {
     expressCancel(
-        adyenCartId: "$expressMaskedQuoteId"
+        adyenMaskedQuoteId: "$expressMaskedQuoteId"
     )
 }
 QUERY;

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2024 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';

--- a/Test/phpunit.xml
+++ b/Test/phpunit.xml
@@ -1,0 +1,42 @@
+<!--
+  ~
+  ~ Adyen Payment Module
+  ~
+  ~ Copyright (c) 2024 Adyen N.V.
+  ~ This file is open source and available under the MIT license.
+  ~ See the LICENSE file for more info.
+  ~
+  ~ Author: Adyen <magento@adyen.com>
+  -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+        bootstrap="./bootstrap.php"
+        colors="true"
+>
+    <php>
+        <ini name="display_errors" value="On"/>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="max_execution_time" value="0"/>
+        <ini name="display_startup_errors" value="On"/>
+        <ini name="error_reporting" value="E_ALL"/>
+        <ini name="date.timezone" value="UTC"/>
+        <server name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="default">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="false">
+        <include>
+            <directory suffix=".php">../.</directory>
+        </include>
+        <exclude>
+            <directory>../vendor</directory>
+            <directory>.</directory>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/Test/phpunit_graphql.php
+++ b/Test/phpunit_graphql.php
@@ -1,0 +1,7 @@
+<?php
+
+ini_set('date.timezone', 'Europe/Amsterdam');
+
+define('TESTS_BASE_URL', 'http://' . getenv('MAGENTO_HOST'));
+define('TESTS_MAGENTO_INSTALLATION', 'disabled');
+define('TESTS_CLEANUP', 'enabled');

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "adyen/module-payment": "^9.7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "*",
+    "phpunit/phpunit": "~9.6.1",
     "magento/magento-coding-standard": "*",
     "squizlabs/php_codesniffer": "*"
   },
@@ -25,5 +25,16 @@
     "psr-4": {
       "Adyen\\ExpressCheckout\\": ""
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Adyen\\ExpressCheckout\\Tests\\": "Test"
+    }
+  },
+  "scripts": {
+    "test": [
+      "Composer\\Config::disableProcessTimeout",
+      "vendor/bin/phpunit -c Test/phpunit.xml"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
   },
   "config": {
     "allow-plugins": {
-      "magento/composer-dependency-version-audit-plugin": true
+      "magento/composer-dependency-version-audit-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
       "Composer\\Config::disableProcessTimeout",
       "vendor/bin/phpunit -c Test/phpunit.xml"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "magento/composer-dependency-version-audit-plugin": true
+    }
   }
 }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -7,7 +7,7 @@ type Mutation {
 
     expressActivate (
         adyenMaskedQuoteId: String! @doc(description: "Adyen express quote ID for PDP")
-        adyenCartId: Int @doc(description: "Original quote ID of the cart")
+        adyenCartId: String @doc(description: "Original quote ID of the cart")
     ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressActivateResolver")
 
     expressCancel (

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -9,6 +9,10 @@ type Mutation {
         adyenMaskedQuoteId: String! @doc(description: "Generated masked quote ID for PDP")
         adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
     ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressActivateResolver")
+
+    expressCancel (
+        adyenCartId: String! @doc(description: "Original quote ID of a shopper")
+    ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressCancelResolver")
 }
 
 type ExpressData {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,117 @@
+type Mutation {
+    expressInit (
+        productCartParams: String! @doc(description: "JSON encoded product cart parameters")
+        adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
+        adyenMaskedQuoteId: String @doc(description: "Generated masked quote ID for PDP")
+    ): ExpressData @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressInitResolver")
+}
+
+type ExpressData {
+    masked_quote_id: String @doc(description: "Generated masked quote ID for PDP")
+    is_virtual_quote: Boolean @doc(description: "Shows whether if the quote is virtual or not")
+    adyen_payment_methods: AdyenPaymentMethods @doc(description: "Lists Adyen payment methods with extra details")
+    totals: Totals @doc(description: "Cart totals")
+}
+
+type AdyenPaymentMethods {
+    extra_details: [ExtraDetail] @doc(description: "Provides icon, method name, configuration and shows whether if the it is open invoice or not")
+    methods_response: [MethodResponse] @doc(description: "Provides configuration from /paymentMethods call as well as method name and supported card brands")
+}
+
+type ExtraDetail {
+    icon: Icon @doc(description: "Payment method icon")
+    configuration: ExtraDetailConfiguration @doc(description: "Configuration object contaning amount and currency")
+    method: String @doc(description: "Payment method name")
+    is_open_invoice: Boolean @doc(description: "Shows whether if it is open invoice or not")
+}
+
+type ExtraDetailConfiguration {
+    amount: Amount @doc(description: "Amount and currency")
+    currency: String @doc(description: "Currency")
+}
+
+type Amount {
+    value: Int @doc(description: "Amount value in minor units")
+    currency: String @doc(description: "Currency")
+}
+
+type Icon {
+    url: String @doc(description: "Payment method icon URL")
+    width: Int @doc(description: "Icon width in pixels")
+    height: Int @doc(description: "Icon height in pixels")
+}
+
+type MethodResponse {
+    configuration: MethodResponseConfiguration @doc(description: "Configuration object returning from /paymentMethods call")
+    name: String @doc(description: "Payment method title")
+    brands: [String] @doc(description: "Supported card networks")
+    type: String @doc(description: "Payment method tx_variant")
+}
+
+type MethodResponseConfiguration {
+    merchant_id: String @doc(description: "Merchant ID from Customer Area")
+    gateway_merchant_id: String @doc(description: "Gateway Merchant ID from Customer Area")
+    intent: String @doc(description: "Intent of payment")
+    merchant_name: String @doc(description: "Merchant account name")
+}
+
+type Totals {
+    grand_total: Float @doc(description: "Grand total in quote currency")
+    base_grand_total: Float @doc(description: "Grand total in base currency")
+    subtotal: Float @doc(description: "Subtotal in quote currency")
+    base_subtotal: Float @doc(description: "Subtotal in quote currency")
+    discount_amount: Float @doc(description: "Discount amount in quote currency")
+    base_discount_amount: Float @doc(description: "Discount amount in base currency")
+    subtotal_with_discount: Float @doc(description: "Subtotal in quote currency with applied discount")
+    base_subtotal_with_discount: Float @doc(description: "Subtotal in base currency with applied discount")
+    shipping_amount: Float @doc(description: "Shipping amount in quote currency")
+    base_shipping_amount: Float @doc(description: "Shipping amount in base currency")
+    shipping_discount_amount: Float @doc(description: "Shipping discount amount in quote currency")
+    base_shipping_discount_amount: Float @doc(description: "Shipping discount amount in base currency")
+    tax_amount: Float @doc(description: "Tax amount in quote currency")
+    base_tax_amount: Float @doc(description: "Tax amount in base currency")
+    weee_tax_applied_amount: Float @doc(description: "The total weee tax applied amount in quote currency")
+    shipping_tax_amount: Float @doc(description: "Shipping tax amount in quote currency")
+    base_shipping_tax_amount: Float @doc(description: "Shipping tax amount in base currency")
+    subtotal_incl_tax: Float @doc(description: "Subtotal including tax in quote currency")
+    base_subtotal_incl_tax: Float @doc(description: "Subtotal including tax in base currency")
+    shipping_incl_tax: Float @doc(description: "Shipping including tax in quote currency")
+    base_shipping_incl_tax: Float @doc(description: "Shipping including tax in base currency")
+    base_currency_code: String @doc(description: "Base currency code")
+    quote_currency_code: String @doc(description: "Quote currency code")
+    coupon_code: String @doc(description: "Applied coupon code")
+    items: [TotalsItem] @doc(description: "Totals by items")
+    total_segments: [TotalSegment] @doc(description: "Dynamically calculated totals")
+    items_qty: Int @doc(description: "Items qty")
+}
+
+type TotalsItem {
+    item_id: Int @doc(description: "Item id")
+    price: Float @doc(description: "Price")
+    base_price: Float @doc(description: "Base price")
+    qty: Float @doc(description: "Quantity")
+    row_total: Float @doc(description: "Row total")
+    base_row_total: Float @doc(description: "Base row total")
+    row_total_with_discount: Float @doc(description: "Row total with discount")
+    discount_amount: Float @doc(description: "Discount amount")
+    base_discount_amount: Float @doc(description: "Base discount amount")
+    discount_percent: Float @doc(description: "Discount percent")
+    tax_amount: Float @doc(description: "Tax amount")
+    base_tax_amount: Float @doc(description: "Base tax amount")
+    tax_percent: Float @doc(description: "Tax percent")
+    price_incl_tax: Float @doc(description: "Price including tax")
+    base_price_incl_tax: Float @doc(description: "Base price including tax")
+    row_total_incl_tax: Float @doc(description: "Row total including tax")
+    base_row_total_incl_tax: Float @doc(description: "Base row total including tax")
+    options: String @doc(description: "Item options data")
+    weee_tax_applied_amount: Float @doc(description: "Item Weee Tax Applied Amount")
+    weee_tax_applied: String @doc(description: "Item Weee Tax Applied Amount")
+    name: String @doc(description: "Item name")
+}
+
+type TotalSegment {
+    code: String @doc(description: "Total code")
+    title: String @doc(description: "Total title")
+    value: Float @doc(description: "Total value")
+    area: String @doc(description: "Display area code")
+}

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,29 +1,29 @@
 type Mutation {
     expressInit (
-        productCartParams: String! @doc(description: "JSON encoded product cart parameters")
-        adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
-        adyenMaskedQuoteId: String @doc(description: "Generated masked quote ID for PDP")
+        productCartParams: String! @doc(description: "JSON encoded product cart parameters (See `ProductCartParamsInterface`)")
+        adyenMaskedQuoteId: String @doc(description: "Adyen express quote ID for PDP")
+        adyenCartId: String @doc(description: "Original quote ID of the cart")
     ): ExpressData @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressInitResolver")
 
     expressActivate (
-        adyenMaskedQuoteId: String! @doc(description: "Generated masked quote ID for PDP")
-        adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
+        adyenMaskedQuoteId: String! @doc(description: "Adyen express quote ID for PDP")
+        adyenCartId: Int @doc(description: "Original quote ID of the cart")
     ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressActivateResolver")
 
     expressCancel (
-        adyenCartId: String! @doc(description: "Original quote ID of a shopper")
+        adyenMaskedQuoteId: String! @doc(description: "Adyen express quote ID for PDP")
     ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressCancelResolver")
 }
 
 type ExpressData {
-    masked_quote_id: String @doc(description: "Generated masked quote ID for PDP")
+    masked_quote_id: String @doc(description: "Adyen express quote ID for PDP")
     is_virtual_quote: Boolean @doc(description: "Shows whether if the quote is virtual or not")
     adyen_payment_methods: AdyenPaymentMethods @doc(description: "Lists Adyen payment methods with extra details")
     totals: Totals @doc(description: "Cart totals")
 }
 
 type AdyenPaymentMethods {
-    extra_details: [ExtraDetail] @doc(description: "Provides icon, method name, configuration and shows whether if the it is open invoice or not")
+    extra_details: [ExtraDetail] @doc(description: "Provides icon, method name, configuration and shows whether if it is an open invoice payment method or not")
     methods_response: [MethodResponse] @doc(description: "Provides configuration from /paymentMethods call as well as method name and supported card brands")
 }
 

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -4,6 +4,11 @@ type Mutation {
         adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
         adyenMaskedQuoteId: String @doc(description: "Generated masked quote ID for PDP")
     ): ExpressData @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressInitResolver")
+
+    expressActivate (
+        adyenMaskedQuoteId: String! @doc(description: "Generated masked quote ID for PDP")
+        adyenCartId: Int @doc(description: "Real cart ID of a logged in shopper")
+    ): Boolean @resolver(class: "Adyen\\ExpressCheckout\\Model\\Resolver\\ExpressActivateResolver")
 }
 
 type ExpressData {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=adyen
+sonar.projectKey=Adyen_adyen-magento2-express-checkout
+sonar.sources=.
+sonar.exclusions=vendor/**/*, Test/**/*, view/**/*
+sonar.php.coverage.reportPaths=build/clover.xml
+sonar.php.tests.reportPath=build/tests-log.xml


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR introduces GraphQL mutations to support headless express integration using GraphQL. As a part of the implementation following mutations were created.

- `expressInit`
- `expressActivate`
- `expressCancel`

Beside implementing those mutations, PHPUnit unit testing and API functional testing frameworks have been implemented.

## Tested scenarios
<!-- Description of tested scenarios -->
- Unit tests
- API functional tests