### PR TITLE
Add shipping methods into Apple Pay Express

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -364,7 +364,7 @@ define([
                     setShippingInformation(shippingInformationPayload, self.isProductView).then(() => {
                         setTotalsInfo(totalsPayload, self.isProductView)
                             .done((response) => {
-                                self.afterSetTotalsInfo(response, shippingMethods[0], self.isProductView, resolve);
+                                self.afterSetTotalsInfo(response, shippingMethods, self.isProductView, resolve);
                             })
                             .fail((e) => {
                                 console.error('Adyen ApplePay: Unable to get totals', e);
@@ -420,6 +420,13 @@ define([
                     label: this.getMerchantName(),
                     amount: (response.grand_total).toString()
                 };
+
+                // If the shipping methods is an array pass all methods to Apple Pay to show in payment window.
+                if (Array.isArray(shippingMethod)) {
+                    applePayShippingMethodUpdate.newShippingMethods = shippingMethod;
+                    shippingMethod = shippingMethod[0];
+                }
+
                 applePayShippingMethodUpdate.newLineItems = [
                     {
                         type: 'final',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Currently when using Apple Pay Express if there are multiple shipping methods available all but the first are ignored and you cannot change your shipping method.

Changed the `onShippingContactSelect` to pass the full array of returned shipping methods into the `afterSetTotalsInfo`. This function then checks if the parameter is an array and if it is will set the `newShippingMethods` so that all shipping methods can be used.

The `onShippingMethodSelect` hasn't been changed and that still passes the single shipping method into the `afterSetTotalsInfo` function as we don't need to change the shipping methods on this callback.

## Tested scenarios
<!-- Description of tested scenarios -->
Tested with Apple Pay using a sandbox Adyen account for delivery addresses with multiple, a single and no shipping methods available.

Adobe Commerce Version: 2.4.5-p9
Adyen Payments: 9.7.1
Adyen Express Checkout: 2.2.1

Fixes #106
