### PR TITLE
[ECP-9535] Start using PAT instead of Github token for release automation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare the next main release
         uses: Adyen/release-automation-action@v1.3.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADYEN_RELEASE_AUTOMATION_USER_TOKEN }}
           develop-branch: main
           version-files: composer.json
           release-title: Adyen Magento 2 Express Checkout Module


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Since `GITHUB_TOKEN` does not trigger workflows, we don't have visibility on release pull requests. With this PR, we have introduced the usage of PAT to trigger workflows.