### PR TITLE
[ECP-9181] Fix broken Google Pay virtual product payments on Android Chrome

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -261,7 +261,7 @@ define([
                     currency = paymentMethodExtraDetails.configuration.amount.currency;
                 }
 
-                return {
+                let configuration = {
                     showPayButton: true,
                     countryCode: config.countryCode,
                     environment: config.checkoutenv.toUpperCase(),
@@ -278,16 +278,12 @@ define([
                         phoneNumberRequired: true
                     },
                     isExpress: true,
-                    callbackIntents: !isVirtual ? ['SHIPPING_ADDRESS', 'SHIPPING_OPTION'] : ['OFFER'],
                     transactionInfo: {
                         totalPriceStatus: 'ESTIMATED',
                         totalPrice: this.isProductView
                             ? formatAmount(totalsModel().getTotal())
                             : formatAmount(getCartSubtotal()),
                         currencyCode: currency
-                    },
-                    paymentDataCallbacks: {
-                        onPaymentDataChanged: this.onPaymentDataChanged.bind(this)
                     },
                     allowedPaymentMethods: ['CARD'],
                     phoneNumberRequired: true,
@@ -302,6 +298,15 @@ define([
                     onError: () => cancelCart(this.isProductView),
                     ...googlePayStyles
                 };
+
+                if (!isVirtual) {
+                    configuration.callbackIntents = ['SHIPPING_ADDRESS', 'SHIPPING_OPTION'];
+                    configuration.paymentDataCallbacks = {
+                        onPaymentDataChanged: this.onPaymentDataChanged.bind(this)
+                    };
+                }
+
+                return configuration;
             },
 
             onPaymentDataChanged: function (data) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Callback intents have been removed to fix the broken payment flow for virtual product payments on Android Chrome browsers.

## Tested scenarios
<!-- Description of tested scenarios -->
- Google Pay express on virtual products on Andoid
- Google Pay express on virtual products on IOS
- Google Pay express normal flow