### PR TITLE
PayPal Express - Tokenization not implemented

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Archive test result artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report
           path: test-report

--- a/Api/AdyenInitPaymentsInterface.php
+++ b/Api/AdyenInitPaymentsInterface.php
@@ -16,6 +16,7 @@ namespace Adyen\ExpressCheckout\Api;
 interface AdyenInitPaymentsInterface
 {
     const PAYMENT_CHANNEL_WEB = 'web';
+    const PAYPAL = 'paypal';
 
     /**
      * @param string $stateData

--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -260,7 +260,7 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
                     $paymentMethodCode,
                     $storeId
                 );
-                
+
                 $request = array_merge($request, [
                     'recurringProcessingModel' => $recurringProcessingModel
                     ]);

--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -96,8 +96,6 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
      */
     private Requests $requestHelper;
 
-    const PAYPAL = 'paypal';
-
     /**
      * @param CartRepositoryInterface $cartRepository
      * @param Config $configHelper

--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -96,6 +96,8 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
      */
     private Requests $requestHelper;
 
+    const PAYPAL = 'paypal';
+
     /**
      * @param CartRepositoryInterface $cartRepository
      * @param Config $configHelper
@@ -180,9 +182,9 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
         }
 
         // Validate payment method
-        if (!isset($stateData['paymentMethod']['type']) || $stateData['paymentMethod']['type'] !== 'paypal') {
+        if (!isset($stateData['paymentMethod']['type']) || $stateData['paymentMethod']['type'] !== self::PAYPAL) {
             throw new ValidatorException(
-                __('Invalid payment method. Only PayPal payments are allowed.')
+                __('Error with payment method please select different payment method.')
             );
         }
 
@@ -226,7 +228,7 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
         $paymentMethodCode = "adyen_{$stateData['paymentMethod']['type']}";
         $userType = $this->userContext->getUserType();
         $customerId = $this->userContext->getUserId();
-        $isLoggedIn = (int)$userType === UserContextInterface::USER_TYPE_CUSTOMER;
+        $isLoggedIn = $userType === UserContextInterface::USER_TYPE_CUSTOMER;
 
         $request = [
             'amount' => [
@@ -256,9 +258,15 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
             $request = array_merge($request, [
                 'storePaymentMethod' => $isRecurringEnabled,
                 'shopperReference' => $shopperReference,
-                'recurringProcessingModel' => $recurringProcessingModel,
                 'shopperInteraction' => 'Ecommerce'
             ]);
+
+            if($isRecurringEnabled)
+            {
+                $request = array_merge($request, [
+                    'recurringProcessingModel' => $recurringProcessingModel
+                    ]);
+            }
         }
 
         return array_merge($request, $stateData);

--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -246,11 +246,6 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
                 $storeId
             );
 
-            $recurringProcessingModel = $this->vaultHelper->getPaymentMethodRecurringProcessingModel(
-                $paymentMethodCode,
-                $storeId
-            );
-
             $shopperReference = $this->requestHelper->getShopperReference($customerId, null);
 
             $request = array_merge($request, [
@@ -261,6 +256,11 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
 
             if($isRecurringEnabled)
             {
+                $recurringProcessingModel = $this->vaultHelper->getPaymentMethodRecurringProcessingModel(
+                    $paymentMethodCode,
+                    $storeId
+                );
+                
                 $request = array_merge($request, [
                     'recurringProcessingModel' => $recurringProcessingModel
                     ]);

--- a/Test/Unit/Model/AdyenInitPaymentsTest.php
+++ b/Test/Unit/Model/AdyenInitPaymentsTest.php
@@ -98,7 +98,6 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
             'clientStateDataIndicator' => true,
             'storePaymentMethod' => null,
             'shopperReference' => '',
-            'recurringProcessingModel' => null,
             'shopperInteraction' => 'Ecommerce'
         ];
 

--- a/Test/Unit/Model/AdyenInitPaymentsTest.php
+++ b/Test/Unit/Model/AdyenInitPaymentsTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * PHPUnit Test for AdyenInitPayments
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model;
+
+use Adyen\ExpressCheckout\Model\AdyenInitPayments;
+use Adyen\Payment\Gateway\Http\Client\TransactionPayment;
+use Adyen\Payment\Gateway\Http\TransferFactory;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\PaymentResponseHandler;
+use Adyen\Payment\Helper\ReturnUrlHelper;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Adyen\Payment\Helper\Requests;
+
+class AdyenInitPaymentsTest extends AbstractAdyenTestCase
+{
+    private AdyenInitPayments $adyenInitPayments;
+    private CartRepositoryInterface $cartRepository;
+    private CheckoutStateDataValidator $checkoutStateDataValidator;
+    private TransferFactory $transferFactory;
+    private TransactionPayment $transactionPaymentClient;
+    private PaymentResponseHandler $paymentResponseHandler;
+
+    protected function setUp(): void
+    {
+        $this->transferMock = $this->createMock(\Magento\Payment\Gateway\Http\TransferInterface::class);
+        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+        $configHelper = $this->createMock(Config::class);
+        $returnUrlHelper = $this->createMock(ReturnUrlHelper::class);
+        $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
+        $this->transferFactory = $this->createMock(TransferFactory::class);
+        $this->transactionPaymentClient = $this->createMock(TransactionPayment::class);
+        $adyenHelper = $this->createMock(Data::class);
+        $this->paymentResponseHandler = $this->createMock(PaymentResponseHandler::class);
+        $quoteIdMaskFactory = $this->createMock(QuoteIdMaskFactory::class);
+        $vaultHelper = $this->createMock(Vault::class);
+        $userContext = $this->createMock(UserContextInterface::class);
+        $requestHelper = $this->createMock(Requests::class);
+        $this->quote = $this->createMock(Quote::class);
+
+        $this->quote->method('getReservedOrderId')->willReturn('1000001');
+        $this->paymentsRequest = [
+            'amount' => [
+                'currency' => null,
+                'value' => null
+            ],
+            'reference' => '1000001',
+            'returnUrl' => '?merchantReference=1000001',
+            'merchantAccount' => 'TestMerchant',
+            'channel' => 'web',
+            'paymentMethod' => [
+                'type' => 'paypal',
+                'userAction' => 'pay',
+                'subtype' => 'express',
+                'checkoutAttemptId' => '3'
+            ],
+            'clientStateDataIndicator' => true
+        ];
+
+        $this->adyenInitPayments = new AdyenInitPayments(
+            $this->cartRepository,
+            $configHelper,
+            $returnUrlHelper,
+            $this->checkoutStateDataValidator,
+            $this->transferFactory,
+            $this->transactionPaymentClient,
+            $adyenHelper,
+            $this->paymentResponseHandler,
+            $quoteIdMaskFactory,
+            $vaultHelper,
+            $userContext,
+            $requestHelper
+        );
+
+        $this->stateData = '{"paymentMethod":{"type":"paypal","userAction":"pay","subtype":"express","checkoutAttemptId":"3"},"clientStateDataIndicator":true,"merchantAccount":"TestMerchant"}';
+
+    }
+
+    public function testExecuteThrowsExceptionForInvalidJson(): void
+    {
+        $this->cartRepository->method('get')->willReturn($this->quote);
+        $this->expectException(ValidatorException::class);
+        $this->adyenInitPayments->execute('{invalidJson}', 1);
+    }
+
+    public function testExecuteThrowsExceptionForInvalidPaymentMethod(): void
+    {
+        $this->cartRepository->method('get')->willReturn($this->quote);
+        $this->expectException(ValidatorException::class);
+        $this->adyenInitPayments->execute(json_encode(['paymentMethod' => ['type' => 'creditcard']]), 1);
+    }
+
+    public function testExecuteHandlesClientException(): void
+    {
+        $this->cartRepository->method('get')->willReturn($this->quote);
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn(json_decode($this->stateData, true));
+        $this->transferFactory->expects($this->once())
+            ->method('create')
+            ->with([
+                'body' => $this->paymentsRequest,
+                'clientConfig' => ['storeId' => $this->quote->getStoreId()]
+            ])
+            ->willReturn($this->transferMock);
+
+        $this->transactionPaymentClient->method('placeRequest')
+            ->willThrowException(new LocalizedException(__('Error with payment method, please select a different payment method!')));
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Error with payment method, please select a different payment method!');
+
+        // Call the method to test exception handling
+        $this->adyenInitPayments->execute($this->stateData, 1);
+    }
+
+    public function testExecuteHandlesSuccessfulPayment()
+    {
+        $this->cartRepository->method('get')->willReturn($this->quote);
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn(json_decode($this->stateData, true));
+
+        $this->transferFactory->method('create')->with([
+            'body' => $this->paymentsRequest,
+            'clientConfig' => ['storeId' => $this->quote->getStoreId()]
+        ])
+            ->willReturn($this->transferMock);
+
+        $this->transactionPaymentClient->method('placeRequest')->willReturn([
+            ['resultCode' => 'Authorised', 'action' => null]
+        ]);
+
+        $this->paymentResponseHandler->method('formatPaymentResponse')->willReturn(['status' => 'success']);
+
+        $response = $this->adyenInitPayments->execute($this->stateData, 1);
+
+        $this->assertJson($response);
+        $this->assertStringContainsString('success', $response);
+    }
+}

--- a/Test/Unit/Model/AdyenInitPaymentsTest.php
+++ b/Test/Unit/Model/AdyenInitPaymentsTest.php
@@ -44,7 +44,9 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
         $this->transactionPaymentClient = $this->createMock(TransactionPayment::class);
         $adyenHelper = $this->createMock(Data::class);
         $this->paymentResponseHandler = $this->createMock(PaymentResponseHandler::class);
-        $quoteIdMaskFactory = $this->createMock(QuoteIdMaskFactory::class);
+        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(QuoteIdMaskFactory::class, [
+            'create'
+        ]);
         $vaultHelper = $this->createMock(Vault::class);
         $userContext = $this->createMock(UserContextInterface::class);
         $requestHelper = $this->createMock(Requests::class);
@@ -78,7 +80,7 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
             $this->transactionPaymentClient,
             $adyenHelper,
             $this->paymentResponseHandler,
-            $quoteIdMaskFactory,
+            $this->quoteIdMaskFactoryMock,
             $vaultHelper,
             $userContext,
             $requestHelper


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PayPal Express does not support tokenization out of the box, as Google and Apple Pay do. When attempting to tokenize with PayPal, the recurringProcessingModel and storedPaymentMethod flags are not sent in with the request, causing the payment to not tokenize as it does through regular checkout.
With this PR, the Tokenization is possible for Paypal Express Payments.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
Tokenizing payments for Paypal Express and Using the Tokens
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
