### PR TITLE
PayPal Express - Two PayPal Tokenization Options

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,7 +32,7 @@
                 <can_refund>1</can_refund>
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
-                <supports_recurring>1</supports_recurring>
+                <supports_recurring>0</supports_recurring>
                 <supports_manual_capture>1</supports_manual_capture>
                 <supports_auto_capture>1</supports_auto_capture>
                 <is_wallet>0</is_wallet>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
With the implementation of PayPal Express, when the Express module is enabled there are two PayPal tokenization options available in the admin tokenization settings in Magento.

When express is disabled, there is only one. Ideally they should both fall under one and seems to be because PayPal Express is implemented as a separate payment method.

This PR aims at having single Paypal Tokenization option for Main module and Express checkout.
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
