### PR TITLE
[ECP-9610] Fix express payment store scope for configuration values

### DIFF
--- a/Observer/AbstractPaymentMethodShortcuts.php
+++ b/Observer/AbstractPaymentMethodShortcuts.php
@@ -15,10 +15,11 @@ use Adyen\ExpressCheckout\Model\Config\Source\ShortcutAreas;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
 use Magento\Catalog\Block\ShortcutButtons;
 use Magento\Catalog\Block\ShortcutInterface;
-use Magento\Checkout\Block\QuoteShortcutButtons;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 abstract class AbstractPaymentMethodShortcuts implements ObserverInterface
 {
@@ -33,15 +34,23 @@ abstract class AbstractPaymentMethodShortcuts implements ObserverInterface
     private ShortcutInterface $shortcutButton;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private StoreManagerInterface $storeManager;
+
+    /**
      * @param ConfigurationInterface $configuration
      * @param ShortcutInterface $shortcutButton
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         ConfigurationInterface $configuration,
-        ShortcutInterface $shortcutButton
+        ShortcutInterface $shortcutButton,
+        StoreManagerInterface $storeManager
     ) {
         $this->configuration = $configuration;
         $this->shortcutButton = $shortcutButton;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -53,7 +62,9 @@ abstract class AbstractPaymentMethodShortcuts implements ObserverInterface
     {
         $currentPageIdentifier = $this->getCurrentPageIdentifier($observer);
         $showPaymentMethodOn = $this->configuration->getShowPaymentMethodOn(
-            $this->shortcutButton->getPaymentMethodVariant()
+            $this->shortcutButton->getPaymentMethodVariant(),
+            ScopeInterface::SCOPE_STORE,
+            $this->storeManager->getStore()->getId()
         );
         if (!in_array(
             $currentPageIdentifier,

--- a/Observer/AddApplePayShortcuts.php
+++ b/Observer/AddApplePayShortcuts.php
@@ -14,13 +14,15 @@ namespace Adyen\ExpressCheckout\Observer;
 use Adyen\ExpressCheckout\Block\ApplePay\Shortcut\Button;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class AddApplePayShortcuts extends AbstractPaymentMethodShortcuts implements ObserverInterface
 {
     public function __construct(
         ConfigurationInterface $configuration,
-        Button $applepayButton
+        Button $applepayButton,
+        StoreManagerInterface $storeManager
     ) {
-        parent::__construct($configuration, $applepayButton);
+        parent::__construct($configuration, $applepayButton, $storeManager);
     }
 }

--- a/Observer/AddGooglePayShortcuts.php
+++ b/Observer/AddGooglePayShortcuts.php
@@ -14,13 +14,15 @@ namespace Adyen\ExpressCheckout\Observer;
 use Adyen\ExpressCheckout\Block\GooglePay\Shortcut\Button;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class AddGooglePayShortcuts extends AbstractPaymentMethodShortcuts implements ObserverInterface
 {
     public function __construct(
         ConfigurationInterface $configuration,
-        Button $googlepayButton
+        Button $googlepayButton,
+        StoreManagerInterface $storeManager
     ) {
-        parent::__construct($configuration, $googlepayButton);
+        parent::__construct($configuration, $googlepayButton, $storeManager);
     }
 }

--- a/Observer/AddPaypalShortcuts.php
+++ b/Observer/AddPaypalShortcuts.php
@@ -14,13 +14,15 @@ namespace Adyen\ExpressCheckout\Observer;
 use Adyen\ExpressCheckout\Block\Paypal\Shortcut\Button;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class AddPaypalShortcuts extends AbstractPaymentMethodShortcuts implements ObserverInterface
 {
     public function __construct(
         ConfigurationInterface $configuration,
-        Button $paypalButton
+        Button $paypalButton,
+        StoreManagerInterface $storeManager
     ) {
-        parent::__construct($configuration, $paypalButton);
+        parent::__construct($configuration, $paypalButton, $storeManager);
     }
 }

--- a/Test/Unit/Observer/AbstractPaymentMethodShortcutsTestCase.php
+++ b/Test/Unit/Observer/AbstractPaymentMethodShortcutsTestCase.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Observer;
+
+use Adyen\ExpressCheckout\Model\ConfigurationInterface;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Catalog\Block\ShortcutInterface;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\View\Layout;
+use Magento\Framework\View\Layout\ProcessorInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+abstract class AbstractPaymentMethodShortcutsTestCase extends AbstractAdyenTestCase
+{
+    protected ?ObserverInterface $addShortcuts;
+    protected MockObject|ConfigurationInterface $configurationMock;
+    protected MockObject|ShortcutInterface $buttonMock;
+    protected MockObject|StoreManagerInterface $storeManagerMock;
+
+    protected function tearDown(): void
+    {
+        $this->addShortcuts = null;
+    }
+
+    private static function executeDataProvider(): array
+    {
+        return [
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => [],
+                'isMinicart' =>  true,
+                'enabledOn' => [1, 3]
+            ],
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => ['catalog_product_view'],
+                'isMinicart' =>  false,
+                'enabledOn' => [1]
+            ],
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => ['checkout_cart_index'],
+                'isMinicart' =>  false,
+                'enabledOn' => [1, 2, 3]
+            ],
+            [
+                'expressEnabledResult' => false
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     *
+     * @param $expressEnabledResult
+     * @param array $identifierHandles
+     * @param bool $isMinicart
+     * @param array $enabledOn
+     * @return void
+     */
+    public function testExecute(
+        $expressEnabledResult,
+        array $identifierHandles = [],
+        bool $isMinicart = false,
+        array $enabledOn = []
+    ) {
+        $processorMock = $this->createMock(ProcessorInterface::class);
+        $processorMock->method('getHandles')->willReturn($identifierHandles);
+
+        $shortcutButtonMock = $this->createGeneratedMock(ShortcutInterface::class, [
+            'setIsProductView',
+            'setIsCart',
+            'getAlias'
+        ]);
+
+        $layoutMock = $this->createMock(Layout::class);
+        $layoutMock->method('getUpdate')->willReturn($processorMock);
+        $layoutMock->method('createBlock')->willReturn($shortcutButtonMock);
+
+        $blockMock = $this->createGeneratedMock(ShortcutInterface::class, [
+            'getAlias', 'getLayout', 'getData', 'addShortcut'
+        ]);
+        $blockMock->method('getLayout')->willReturn($layoutMock);
+        $blockMock->method('getData')->willReturn($isMinicart);
+
+        $eventMock = $this->createGeneratedMock(Event::class, ['getContainer']);
+        $eventMock->method('getContainer')->willReturn($blockMock);
+
+        $observerMock = $this->createMock(Observer::class);
+        $observerMock->method('getEvent')->willReturn($eventMock);
+
+        $this->configurationMock->expects($this->once())
+            ->method('getShowPaymentMethodOn')
+            ->willReturn($enabledOn);
+
+        if ($expressEnabledResult) {
+            $blockMock->expects($this->once())->method('addShortcut');
+        }
+
+        $this->addShortcuts->execute($observerMock);
+    }
+}

--- a/Test/Unit/Observer/AddApplePayShortcutsTest.php
+++ b/Test/Unit/Observer/AddApplePayShortcutsTest.php
@@ -11,13 +11,13 @@
 
 namespace Adyen\ExpressCheckout\Test\Unit\Observer;
 
-use Adyen\ExpressCheckout\Block\GooglePay\Shortcut\Button as GooglePayButton;
+use Adyen\ExpressCheckout\Block\ApplePay\Shortcut\Button as ApplePayButton;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
-use Adyen\ExpressCheckout\Observer\AddGooglePayShortcuts;
+use Adyen\ExpressCheckout\Observer\AddApplePayShortcuts;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
-class AddGooglePayShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
+class AddApplePayShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
 {
     protected function setUp(): void
     {
@@ -25,11 +25,11 @@ class AddGooglePayShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
         $storeMock->method('getId')->willReturn(1);
 
         $this->configurationMock = $this->createMock(ConfigurationInterface::class);
-        $this->buttonMock = $this->createMock(GooglePayButton::class);
+        $this->buttonMock = $this->createMock(ApplePayButton::class);
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
         $this->storeManagerMock->method('getStore')->willReturn($storeMock);
 
-        $this->addShortcuts = new AddGooglePayShortcuts(
+        $this->addShortcuts = new AddApplePayShortcuts(
             $this->configurationMock,
             $this->buttonMock,
             $this->storeManagerMock

--- a/Test/Unit/Observer/AddGooglePayShortcutsTest.php
+++ b/Test/Unit/Observer/AddGooglePayShortcutsTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\ExpressCheckout\Test\Unit\Observer;
+
+use Adyen\ExpressCheckout\Block\GooglePay\Shortcut\Button as GooglePayButton;
+use Adyen\ExpressCheckout\Model\ConfigurationInterface;
+use Adyen\ExpressCheckout\Observer\AddGooglePayShortcuts;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Catalog\Block\ShortcutInterface;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Layout;
+use Magento\Framework\View\Layout\ProcessorInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AddGooglePayShortcutsTest extends AbstractAdyenTestCase
+{
+    protected ?AddGooglePayShortcuts $addGooglePayShortcuts;
+    protected MockObject|ConfigurationInterface $configurationMock;
+    protected MockObject|GooglePayButton $googlepayButtonMock;
+    protected MockObject|StoreManagerInterface $storeManagerMock;
+
+    protected function setUp(): void
+    {
+        $storeMock = $this->createMock(StoreInterface::class);
+        $storeMock->method('getId')->willReturn(1);
+
+        $this->configurationMock = $this->createMock(ConfigurationInterface::class);
+        $this->googlepayButtonMock = $this->createMock(GooglePayButton::class);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $this->addGooglePayShortcuts = new AddGooglePayShortcuts(
+            $this->configurationMock,
+            $this->googlepayButtonMock,
+            $this->storeManagerMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->addGooglePayShortcuts = null;
+    }
+
+    private static function executeDataProvider(): array
+    {
+        return [
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => [],
+                'isMinicart' =>  true
+            ],
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => ['catalog_product_view']
+            ],
+            [
+                'expressEnabledResult' => true,
+                'identifierHandles' => ['checkout_cart_index']
+            ],
+            [
+                'expressEnabledResult' => false
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     *
+     * @param $expressEnabledResult
+     * @param array $identifierHandles
+     * @param bool $isMinicart
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testExecute(
+        $expressEnabledResult,
+        array $identifierHandles = [],
+        bool $isMinicart = false
+    ) {
+        $processorMock = $this->createMock(ProcessorInterface::class);
+        $processorMock->method('getHandles')->willReturn($identifierHandles);
+
+        $shortcutButtonMock = $this->createGeneratedMock(ShortcutInterface::class, [
+            'setIsProductView',
+            'setIsCart',
+            'getAlias'
+        ]);
+
+        $layoutMock = $this->createMock(Layout::class);
+        $layoutMock->method('getUpdate')->willReturn($processorMock);
+        $layoutMock->method('createBlock')->willReturn($shortcutButtonMock);
+
+        $blockMock = $this->createGeneratedMock(ShortcutInterface::class, [
+            'getAlias', 'getLayout', 'getData', 'addShortcut'
+        ]);
+        $blockMock->method('getLayout')->willReturn($layoutMock);
+        $blockMock->method('getData')->willReturn($isMinicart);
+
+        $eventMock = $this->createGeneratedMock(Event::class, ['getContainer']);
+        $eventMock->method('getContainer')->willReturn($blockMock);
+
+        $observerMock = $this->createMock(Observer::class);
+        $observerMock->method('getEvent')->willReturn($eventMock);
+
+        $this->configurationMock->expects($this->once())
+            ->method('getShowPaymentMethodOn')
+            ->willReturn([1,2,3]);
+
+        if ($expressEnabledResult) {
+            $blockMock->expects($this->once())->method('addShortcut');
+        }
+
+        $this->addGooglePayShortcuts->execute($observerMock);
+    }
+}

--- a/Test/Unit/Observer/AddPaypalShortcutsTest.php
+++ b/Test/Unit/Observer/AddPaypalShortcutsTest.php
@@ -11,13 +11,13 @@
 
 namespace Adyen\ExpressCheckout\Test\Unit\Observer;
 
-use Adyen\ExpressCheckout\Block\GooglePay\Shortcut\Button as GooglePayButton;
+use Adyen\ExpressCheckout\Block\Paypal\Shortcut\Button as PaypalButton;
 use Adyen\ExpressCheckout\Model\ConfigurationInterface;
-use Adyen\ExpressCheckout\Observer\AddGooglePayShortcuts;
+use Adyen\ExpressCheckout\Observer\AddPaypalShortcuts;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
-class AddGooglePayShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
+class AddPaypalShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
 {
     protected function setUp(): void
     {
@@ -25,11 +25,11 @@ class AddGooglePayShortcutsTest extends AbstractPaymentMethodShortcutsTestCase
         $storeMock->method('getId')->willReturn(1);
 
         $this->configurationMock = $this->createMock(ConfigurationInterface::class);
-        $this->buttonMock = $this->createMock(GooglePayButton::class);
+        $this->buttonMock = $this->createMock(PaypalButton::class);
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
         $this->storeManagerMock->method('getStore')->willReturn($storeMock);
 
-        $this->addShortcuts = new AddGooglePayShortcuts(
+        $this->addShortcuts = new AddPaypalShortcuts(
             $this->configurationMock,
             $this->buttonMock,
             $this->storeManagerMock

--- a/Test/Unit/Observer/UpdatePaypalOrderStatusTest.php
+++ b/Test/Unit/Observer/UpdatePaypalOrderStatusTest.php
@@ -9,7 +9,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\ExpressCheckout\Test\Unit\Model\Resolver;
+namespace Adyen\ExpressCheckout\Test\Unit\Observer;
 
 use Adyen\ExpressCheckout\Block\Paypal\Shortcut\Button;
 use Adyen\ExpressCheckout\Observer\UpdatePaypalOrderStatus;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR fixes the issue of not having store scopes for configuration values for express payment methods. The PR introduces the store scope to fetch the correct configuration value based on the `store` or `website`. So that, the express payment methods will only be rendered on the stores in which the express payments are enabled.

## Tested scenarios
<!-- Description of tested scenarios -->
- Use 2 stores to test express module's activation