### PR TITLE
[ECP-9747] Revisiting the approach to validate the Shipping Methods for PaypalUpdateOrder call

### DIFF
--- a/Helper/Util/PaypalDeliveryMethodValidator.php
+++ b/Helper/Util/PaypalDeliveryMethodValidator.php
@@ -13,19 +13,45 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Helper\Util;
 
-use Adyen\Payment\Helper\Util\DataArrayValidator;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Framework\Phrase;
 
 class PaypalDeliveryMethodValidator implements PaypalDeliveryMethodValidatorInterface
 {
+    /**
+     * Validates the delivery method array
+     *
+     * @param array $deliveryMethod
+     * @return array
+     * @throws ValidatorException
+     */
     public function getValidatedDeliveryMethod(array $deliveryMethod): array
     {
-        if (!empty($deliveryMethod)) {
-            $deliveryMethod = DataArrayValidator::getArrayOnlyWithApprovedKeys(
-                $deliveryMethod,
-                self::DELIVERY_METHOD_FIELDS
+        if (empty($deliveryMethod)) {
+            throw new ValidatorException(
+                __('Shipping methods are missing.')
             );
         }
 
-        return $deliveryMethod;
+        $validatedDeliveryMethod = [];
+
+        foreach (self::DELIVERY_METHOD_FIELDS as $key) {
+            if (!array_key_exists($key, $deliveryMethod)) {
+                throw new ValidatorException(
+                    __("Missing required delivery method field: '%1'", [$key])
+                );
+            }
+
+            $value = $deliveryMethod[$key];
+            if ($value === null || $value === '') {
+                throw new ValidatorException(
+                    __("Delivery method field '%1' cannot be empty or null.", [$key])
+                );
+            }
+
+            $validatedDeliveryMethod[$key] = $value;
+        }
+
+        return $validatedDeliveryMethod;
     }
 }

--- a/Helper/Util/PaypalDeliveryMethodValidator.php
+++ b/Helper/Util/PaypalDeliveryMethodValidator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Helper\Util;
 
 use Magento\Framework\Exception\ValidatorException;
-use Magento\Framework\Phrase;
 
 class PaypalDeliveryMethodValidator implements PaypalDeliveryMethodValidatorInterface
 {

--- a/Model/AdyenPaypalUpdateOrder.php
+++ b/Model/AdyenPaypalUpdateOrder.php
@@ -27,7 +27,6 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
-use phpseclib3\Crypt\EC\Curves\prime192v1;
 
 class AdyenPaypalUpdateOrder implements AdyenPaypalUpdateOrderInterface
 {

--- a/Test/Unit/Helper/Util/PaypalDeliveryMethodValidatorTest.php
+++ b/Test/Unit/Helper/Util/PaypalDeliveryMethodValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Helper\Util;
+
+use Adyen\ExpressCheckout\Helper\Util\PaypalDeliveryMethodValidator;
+use Magento\Framework\Exception\ValidatorException;
+use PHPUnit\Framework\TestCase;
+
+class PaypalDeliveryMethodValidatorTest extends TestCase
+{
+    private PaypalDeliveryMethodValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new PaypalDeliveryMethodValidator();
+    }
+
+    public function testValidDeliveryMethod(): void
+    {
+        $validInput = [
+            'reference' => '1',
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => [
+                'currency' => 'MXN',
+                'value' => 500
+            ],
+            'selected' => '1'
+        ];
+
+        $result = $this->validator->getValidatedDeliveryMethod($validInput);
+        $this->assertSame($validInput, $result);
+    }
+
+    public function testEmptyDeliveryMethodThrowsException(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('Shipping methods are missing.');
+
+        $this->validator->getValidatedDeliveryMethod([]);
+    }
+
+    public function testMissingFieldThrowsException(): void
+    {
+        $input = [
+            'reference' => '1',
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => [
+                'currency' => 'MXN',
+                'value' => 500
+            ]
+            // 'selected' is missing
+        ];
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage("Missing required delivery method field: 'selected'");
+
+        $this->validator->getValidatedDeliveryMethod($input);
+    }
+
+    public function testNullFieldThrowsException(): void
+    {
+        $input = [
+            'reference' => null,
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => [
+                'currency' => 'MXN',
+                'value' => 500
+            ],
+            'selected' => '1'
+        ];
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage("Delivery method field 'reference' cannot be empty or null.");
+
+        $this->validator->getValidatedDeliveryMethod($input);
+    }
+}

--- a/Test/Unit/Helper/Util/PaypalDeliveryMethodValidatorTest.php
+++ b/Test/Unit/Helper/Util/PaypalDeliveryMethodValidatorTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Test\Unit\Helper\Util;
 
 use Adyen\ExpressCheckout\Helper\Util\PaypalDeliveryMethodValidator;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\Exception\ValidatorException;
-use PHPUnit\Framework\TestCase;
 
-class PaypalDeliveryMethodValidatorTest extends TestCase
+class PaypalDeliveryMethodValidatorTest extends AbstractAdyenTestCase
 {
     private PaypalDeliveryMethodValidator $validator;
 

--- a/Test/Unit/Model/AdyenPaypalUpdateOrderTest.php
+++ b/Test/Unit/Model/AdyenPaypalUpdateOrderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model;
+
+use Adyen\AdyenException;
+use Adyen\ExpressCheckout\Helper\PaypalUpdateOrder;
+use Adyen\ExpressCheckout\Helper\Util\PaypalDeliveryMethodValidator;
+use Adyen\ExpressCheckout\Model\AdyenPaypalUpdateOrder;
+use Adyen\ExpressCheckout\Model\ResourceModel\PaymentResponse\Collection as AdyenPaymentResponseCollection;
+use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AdyenPaypalUpdateOrderTest extends AbstractAdyenTestCase
+{
+    private AdyenPaypalUpdateOrder $model;
+
+    private MockObject $paypalUpdateOrderHelper;
+    private MockObject $cartRepository;
+    private MockObject $deliveryMethodValidator;
+    private MockObject $chargedCurrency;
+    private MockObject $adyenHelper;
+    private MockObject $paymentResponseCollection;
+    private MockObject $quoteIdMaskFactory;
+
+    protected function setUp(): void
+    {
+        $this->paypalUpdateOrderHelper = $this->createMock(PaypalUpdateOrder::class);
+        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+        $this->deliveryMethodValidator = $this->createMock(PaypalDeliveryMethodValidator::class);
+        $this->chargedCurrency = $this->createMock(ChargedCurrency::class);
+        $this->adyenHelper = $this->createMock(Data::class);
+        $this->paymentResponseCollection = $this->createMock(AdyenPaymentResponseCollection::class);
+        $this->quoteIdMaskFactory = $this->createMock(QuoteIdMaskFactory::class);
+
+        $this->model = new AdyenPaypalUpdateOrder(
+            $this->paypalUpdateOrderHelper,
+            $this->cartRepository,
+            $this->deliveryMethodValidator,
+            $this->chargedCurrency,
+            $this->adyenHelper,
+            $this->paymentResponseCollection,
+            $this->quoteIdMaskFactory
+        );
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    public function testExecuteThrowsExceptionForMissingMerchantReference(): void
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getReservedOrderId')->willReturn(null);
+
+        $this->cartRepository->method('get')->willReturn($quote);
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('Order ID has not been reserved!');
+
+        $deliveryMethods = json_encode([
+            ['reference' => '1', 'description' => 'flatrate', 'type' => 'Shipping', 'amount' => ['currency' => 'MXN', 'value' => 100], 'selected' => true]
+        ]);
+        $this->deliveryMethodValidator->method('getValidatedDeliveryMethod')->willReturn([
+            'reference' => '1',
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => ['currency' => 'MXN', 'value' => 100],
+            'selected' => true
+        ]);
+
+        $this->model->execute('somePaymentData', 1, null, $deliveryMethods);
+    }
+
+    public function testExecuteThrowsExceptionIfPaymentResponseMissing(): void
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getReservedOrderId')->willReturn('ORD123');
+        $quote->method('getStoreId')->willReturn(1);
+        $this->cartRepository->method('get')->willReturn($quote);
+
+        $this->paymentResponseCollection
+            ->method('getPaymentResponseWithMerchantReference')
+            ->with('ORD123')
+            ->willReturn(null);
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage("Payment response couldn't be found!");
+
+        $deliveryMethods = json_encode([
+            ['reference' => '1', 'description' => 'flatrate', 'type' => 'Shipping', 'amount' => ['currency' => 'MXN', 'value' => 100], 'selected' => true]
+        ]);
+
+        $this->deliveryMethodValidator->method('getValidatedDeliveryMethod')->willReturn([
+            'reference' => '1',
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => ['currency' => 'MXN', 'value' => 100],
+            'selected' => true
+        ]);
+
+        $this->model->execute('somePaymentData', 1, null, $deliveryMethods);
+    }
+
+    public function testExecuteReturnsJsonOnSuccess(): void
+    {
+        $quoteId = 10;
+        $merchantReference = 'ORD123';
+        $currency = 'USD';
+        $grandTotal = 100;
+        $taxAmount = 5;
+        $formattedAmount = 10000;
+        $formattedTaxAmount = 500;
+
+        $quote = $this->createMockWithMethods(
+            Quote::class,
+            ['getStoreId', 'getReservedOrderId', 'isVirtual', 'getShippingAddress'],
+            ['getGrandTotal']
+        );
+
+        $quote->method('getReservedOrderId')->willReturn($merchantReference);
+        $quote->method('getStoreId')->willReturn(1);
+        $quote->method('getGrandTotal')->willReturn($grandTotal);
+        $quote->method('isVirtual')->willReturn(false);
+
+        $address = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getTaxAmount'])
+            ->getMock();
+        $address->method('getTaxAmount')->willReturn($taxAmount);
+
+        $quote->method('getShippingAddress')->willReturn($address);
+
+        $this->cartRepository->method('get')->with($quoteId)->willReturn($quote);
+
+        $this->paymentResponseCollection->method('getPaymentResponseWithMerchantReference')
+            ->willReturn(['response' => json_encode(['pspReference' => 'PSP123'])]);
+
+        $this->chargedCurrency->method('getQuoteAmountCurrency')->willReturn(
+            $this->createConfiguredMock(\Adyen\Payment\Model\AdyenAmountCurrency::class, [
+                'getCurrencyCode' => $currency
+            ])
+        );
+
+        $this->adyenHelper->method('formatAmount')->willReturnMap([
+            [$grandTotal, $currency, $formattedAmount],
+            [$taxAmount, $currency, $formattedTaxAmount]
+        ]);
+
+        $validatedDeliveryMethod = [
+            'reference' => '1',
+            'description' => 'flatrate',
+            'type' => 'Shipping',
+            'amount' => ['currency' => $currency, 'value' => 1000],
+            'selected' => true
+        ];
+
+        $this->deliveryMethodValidator->method('getValidatedDeliveryMethod')->willReturn($validatedDeliveryMethod);
+
+        $this->adyenHelper->expects($this->once())->method('logRequest');
+
+        $deliveryMethods = json_encode([$validatedDeliveryMethod]);
+        $this->model->execute('somePaymentData', $quoteId, null, $deliveryMethods);
+    }
+}

--- a/Test/Unit/Model/AdyenPaypalUpdateOrderTest.php
+++ b/Test/Unit/Model/AdyenPaypalUpdateOrderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Test\Unit\Model;
 
-use Adyen\AdyenException;
 use Adyen\ExpressCheckout\Helper\PaypalUpdateOrder;
 use Adyen\ExpressCheckout\Helper\Util\PaypalDeliveryMethodValidator;
 use Adyen\ExpressCheckout\Model\AdyenPaypalUpdateOrder;
@@ -16,10 +15,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
-use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
 class AdyenPaypalUpdateOrderTest extends AbstractAdyenTestCase
 {

--- a/view/frontend/web/js/actions/updatePaypalOrder.js
+++ b/view/frontend/web/js/actions/updatePaypalOrder.js
@@ -41,16 +41,23 @@ define([
                 isSelected = true;
             }
 
+            // Fallback logic for description
+            let description =
+                shippingMethods[i].detail?.trim() ||
+                shippingMethods[i].label?.trim() ||
+                shippingMethods[i].carrierCode
+
             let method = {
                 reference: (i + 1).toString(),
-                description: shippingMethods[i].detail,
+                description: description,
                 type: 'Shipping',
                 amount: {
                     currency: currency,
-                        value: currencyHelper.formatAmount(Math.round(shippingMethods[i].amount), currency)
+                    value: currencyHelper.formatAmount(Math.round(shippingMethods[i].amount), currency)
                 },
                 selected: isSelected
             };
+
             // Add method object to array.
             deliveryMethods.push(method);
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
While setting the Shipping methods in Magento, The `detail` and `Label` of a shipping method in Magento is not a required field.
And this `detail` is mapped to the `description`(which is a required field), while send the shipping methods to PaypalExpress UpdateOrder call.
Updating the fallback mechanism to `carrierCode` if the `detail` or `Label` is not defined or empty.

