### PR TITLE
[ECP-9754] Paypal Express issues with Rounding off the shipping amount

### DIFF
--- a/view/frontend/web/js/actions/updatePaypalOrder.js
+++ b/view/frontend/web/js/actions/updatePaypalOrder.js
@@ -53,7 +53,7 @@ define([
                 type: 'Shipping',
                 amount: {
                     currency: currency,
-                    value: currencyHelper.formatAmount(Math.round(shippingMethods[i].amount), currency)
+                    value: currencyHelper.formatAmount(shippingMethods[i].amount, currency)
                 },
                 selected: isSelected
             };

--- a/view/frontend/web/js/paypal_express/button.js
+++ b/view/frontend/web/js/paypal_express/button.js
@@ -413,7 +413,7 @@ define([
                         return actions.reject();
                     }
                 },
-                onShippingOptionsChange: async function (data, actions, component) {
+                onShippingOptionsChange: async (data, actions, component) => {
                     const currentPaymentData = component.paymentData;
                     const selectedShippingLabel = data.selectedShippingOption.label?.trim();
 

--- a/view/frontend/web/js/paypal_express/button.js
+++ b/view/frontend/web/js/paypal_express/button.js
@@ -360,14 +360,21 @@ define([
                 onShippingOptionsChange: async (data, actions, component) => {
                     let shippingMethod = [];
                     const currentPaymentData = component.paymentData;
+
                     for (const method of Object.values(this.shippingMethods)) {
-                        if (method.carrier_title === data.selectedShippingOption.label) {
-                            this.shippingMethod = method.method_code;
+                        if ((method.carrier_code === data.selectedShippingOption.label) || (method.carrier_title === data.selectedShippingOption.label) ) {
+                            this.shippingMethod = method.method_code || method.carrier_code;
+                            let description =
+                                method.carrier_title?.trim() ||
+                                method.method_title?.trim() ||
+                                method.carrier_code;
+                            let label = method.method_title?.trim() ||
+                                method.carrier_code;
                             shippingMethod = {
                                 identifier: method.method_code,
-                                label: method.method_title,
-                                detail: method.carrier_title ? method.carrier_title : '',
-                                amount: parseFloat(method.amount).toFixed(2),
+                                label: label,
+                                detail: description,
+                                amount: method.amount,
                                 carrierCode: method.carrier_code,
                             };
                             break;
@@ -534,11 +541,19 @@ define([
                         if (typeof method.method_code !== 'string') {
                             continue;
                         }
+                        let description =
+                            method.carrier_title?.trim() ||
+                            method.method_title?.trim() ||
+                            method.carrier_code;
+
+                        let label = method.method_title?.trim() ||
+                        method.carrier_code;
+
                         let shippingMethod = {
                             identifier: method.method_code,
-                            label: method.method_title,
-                            detail: method.carrier_title ? method.carrier_title : '',
-                            amount: parseFloat(method.amount).toFixed(2),
+                            label: label,
+                            detail: description,
+                            amount: method.amount,
                             carrierCode: method.carrier_code,
                         };
                         shippingMethods.push(shippingMethod);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When the shipping price is excluding tax, and the shipping price is 0 the flow is happy. If for example shipping is set to 5.99 the amount is rounded and the /updateOrder call fails due to the rounding up and the amount being higher than the original offer.
When changing the Flat Rate method to Price = 4.99 in the admin, the PayPal popup was displaying the **incorrect price** again because of the failing call to updateOrder, resulting in the "Unable to update address." error in the PayPal popup.
Please note that the price is output as 5.99 in the frontend, again because of the tax configuration (i.e. 4.99 + 20% VAT = ~5.99). In the call the amount is rounded up to 6.00.
This PR aims to solve the issues which handles the rounding off of the Shipping amount and also some part of the Code also handles the logic where Shipping Title and description is not set, as that is not the required field

**Fixed issue**:  <!-- #-prefixed issue number -->
#128 