### PR TITLE
[ECP-9773] Support PHP Unit 10 on the Express module

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -23,7 +23,8 @@ MAGENTO_LANGUAGE=en_US \
 MAGENTO_CURRENCY=EUR \
 MAGENTO_TZ=Europe/Amsterdam \
 DEPLOY_SAMPLEDATA=0 \
-USE_SSL=1
+USE_SSL=1 \
+XDEBUG_MODE=coverage
 
 RUN apt-get update \
     && apt-get install -y libjpeg62-turbo-dev \
@@ -41,9 +42,12 @@ RUN apt-get update \
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN a2enmod ssl
-RUN a2ensite default-ssl.conf #can be removed if not needed
+RUN a2ensite default-ssl.conf
+
 WORKDIR /var/www/html
+
 COPY config/php.ini /usr/local/etc/php/
 COPY scripts/install_magento.sh /tmp/install_magento.sh
 

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -15,7 +15,6 @@ magento:
 install:
 	composer config --json repositories.local '{"type": "path", "url": "/data/extensions/workdir", "options": { "symlink": false } }'
 	composer require "adyen/adyen-magento2-expresscheckout:*"
-	vendor/bin/phpcs --standard=Magento2 --extensions=php,phtml --error-severity=10 --ignore-annotations -n -p vendor/adyen/adyen-magento2-expresscheckout
 	bin/magento module:enable --all
 	bin/magento setup:upgrade
 	bin/magento setup:di:compile
@@ -65,3 +64,20 @@ graphql:
 
 phpstan-run:
 	vendor/bin/phpstan analyse -c vendor/adyen/adyen-magento2-expresscheckout/phpstan.neon
+
+phpunit-run:
+	cp vendor/adyen/adyen-magento2-expresscheckout/Test/phpunit.xml.dist dev/tests/unit/phpunit.xml
+	cd dev/tests/unit; \
+		../../../vendor/bin/phpunit \
+		--coverage-clover=../../../build/clover.xml \
+		--log-junit=../../../build/tests-log.xml \
+		-c phpunit.xml \
+		../../../vendor/adyen/adyen-magento2-expresscheckout/Test/Unit
+
+codesniffer-run:
+	vendor/bin/phpcs --standard=Magento2 \
+		--extensions=php,phtml \
+		--error-severity=10 \
+		--warning-severity=0 \
+		--ignore-annotations \
+		-p vendor/adyen/adyen-magento2-expresscheckout

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - ./Makefile:/var/www/html/Makefile
       - composer:/usr/local/bin
       - magento:/var/www/html
+      - ../build:/var/www/html/build
 networks:
   backend:
 volumes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,33 +15,52 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.2,8.3]
+        php-version: [ "8.3" ]
+        magento-version: [ "2.4.8" ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PHP_VERSION: ${{ matrix.php-version }}
+      MAGENTO_VERSION: ${{ matrix.magento-version }}
+      ADYEN_API_KEY: ${{secrets.ADYEN_API_KEY}}
+      ADYEN_CLIENT_KEY: ${{secrets.ADYEN_CLIENT_KEY}}
+      ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
+      ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
+      ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
+      DONATION_ACCOUNT: ${{secrets.DONATION_ACCOUNT}}
+      DEPLOY_SAMPLEDATA: 1
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          tools: composer:v2
+      - name: Install Magento
+        run: docker compose -f .github/docker-compose.yml run --rm web make magento
 
-      - name: Test plugin installation
-        run: |
-          echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json
-          composer install --prefer-dist
-        env:
-          CI: true
-          MAGENTO_USERNAME: ${{ secrets.MAGENTO_USERNAME }}
-          MAGENTO_PASSWORD: ${{ secrets.MAGENTO_PASSWORD }}
+      - name: Start web server in background
+        run: docker compose -f .github/docker-compose.yml up -d web
+
+      - name: Setup permissions
+        run: docker exec magento2-container make fs
+
+      - name: Check install
+        run: docker exec magento2-container make sys-check
+
+      - name: Install plugin
+        run: docker exec -u www-data magento2-container make plugin
+
+      - name: Kill Cron Jobs
+        run: docker exec magento2-container /etc/init.d/cron stop
+
+      - name: Setup permissions
+        run: docker exec magento2-container make fs
+
+      - name: Run PHP_Codesniffer
+        run: docker exec magento2-container make codesniffer-run
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit --coverage-clover=build/clover.xml --log-junit=build/tests-log.xml -c Test/phpunit.xml Test/Unit
-
-      - name: Fix code coverage paths
-        run: sed -i "s;`pwd`/;;g" build/*.xml
+        run: docker exec magento2-container make phpunit-run
 
       - name: SonarCloud Scan
         if: ${{ env.SONAR_TOKEN }}
@@ -49,3 +68,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Run PHPStan
+        run: docker exec magento2-container make phpstan-run

--- a/Test/Unit/Helper/PaypalUpdateOrderTest.php
+++ b/Test/Unit/Helper/PaypalUpdateOrderTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Helper;
+
+use Adyen\AdyenException;
+use Adyen\Client;
+use Adyen\ExpressCheckout\Helper\PaypalUpdateOrder;
+use Adyen\Model\Checkout\Amount;
+use Adyen\Model\Checkout\DeliveryMethod;
+use Adyen\Model\Checkout\PaypalUpdateOrderRequest;
+use Adyen\Model\Checkout\PaypalUpdateOrderResponse;
+use Adyen\Model\Checkout\TaxTotal;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Adyen\Service\Checkout\UtilityApi;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(PaypalUpdateOrder::class)]
+class PaypalUpdateOrderTest extends AbstractAdyenTestCase
+{
+    private Data $adyenHelper;
+    private PaypalUpdateOrder $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adyenHelper = $this->createMock(Data::class);
+        $this->subject = new PaypalUpdateOrder($this->adyenHelper);
+    }
+
+    public function testBuildPaypalUpdateOrderRequestWithoutDeliveryMethods(): void
+    {
+        $pspReference   = 'PSP123';
+        $paymentData    = 'payment-data-token';
+        $amountValue    = 12345;
+        $taxAmount      = 2345;
+        $currency       = 'EUR';
+
+        $request = $this->subject->buildPaypalUpdateOrderRequest(
+            $pspReference,
+            $paymentData,
+            $amountValue,
+            $taxAmount,
+            $currency,
+            [] // no delivery methods
+        );
+
+        $this->assertInstanceOf(PaypalUpdateOrderRequest::class, $request);
+
+        // Core fields
+        $this->assertSame($pspReference, $request->getPspReference());
+        $this->assertSame($paymentData, $request->getPaymentData());
+
+        // Amount
+        $this->assertInstanceOf(Amount::class, $request->getAmount());
+        $this->assertSame($amountValue, $request->getAmount()->getValue());
+        $this->assertSame($currency, $request->getAmount()->getCurrency());
+
+        // Tax total
+        $this->assertInstanceOf(TaxTotal::class, $request->getTaxTotal());
+        $this->assertInstanceOf(Amount::class, $request->getTaxTotal()->getAmount());
+        $this->assertSame($taxAmount, $request->getTaxTotal()->getAmount()->getValue());
+        $this->assertSame($currency, $request->getTaxTotal()->getAmount()->getCurrency());
+
+        // Delivery methods should not be set if input was empty
+        $this->assertNull($request->getDeliveryMethods());
+    }
+
+    public function testBuildPaypalUpdateOrderRequestWithDeliveryMethods(): void
+    {
+        $pspReference   = 'PSP456';
+        $paymentData    = 'another-payment-data';
+        $amountValue    = 5000;
+        $taxAmount      = 1000;
+        $currency       = 'USD';
+
+        // Shape is flexible; DeliveryMethod accepts an array and we only assert instances/count.
+        $deliveryMethods = [
+            ['id' => 'std', 'name' => 'Standard Shipping'],
+            ['id' => 'exp', 'name' => 'Express Shipping'],
+        ];
+
+        $request = $this->subject->buildPaypalUpdateOrderRequest(
+            $pspReference,
+            $paymentData,
+            $amountValue,
+            $taxAmount,
+            $currency,
+            $deliveryMethods
+        );
+
+        $this->assertInstanceOf(PaypalUpdateOrderRequest::class, $request);
+        $this->assertIsArray($request->getDeliveryMethods());
+        $this->assertCount(2, $request->getDeliveryMethods());
+
+        foreach ($request->getDeliveryMethods() as $dm) {
+            $this->assertInstanceOf(DeliveryMethod::class, $dm);
+        }
+    }
+
+    public function testHandlePaypalUpdateOrderResponse(): void
+    {
+        $response = $this->createMock(PaypalUpdateOrderResponse::class);
+        $response->method('getStatus')->willReturn('success');
+        $response->method('getPaymentData')->willReturn('pd-xyz');
+
+        $result = $this->subject->handlePaypalUpdateOrderResponse($response);
+
+        $this->assertSame(
+            ['status' => 'success', 'paymentData' => 'pd-xyz'],
+            $result
+        );
+    }
+
+    public function testCreateAdyenUtilityApiServiceBubblesExceptions(): void
+    {
+        $storeId = 7;
+
+        $this->adyenHelper
+            ->expects($this->once())
+            ->method('initializeAdyenClient')
+            ->with($storeId)
+            ->willThrowException(new NoSuchEntityException(__('Store not found')));
+
+        $this->expectException(NoSuchEntityException::class);
+
+        // Should bubble up the exception as declared in the signature
+        $this->subject->createAdyenUtilityApiService($storeId);
+    }
+}

--- a/Test/Unit/Model/AdyenPaymentMethodsTest.php
+++ b/Test/Unit/Model/AdyenPaymentMethodsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model;
+
+use Adyen\ExpressCheckout\Api\Data\AdyenPaymentMethodsInterface;
+use Adyen\ExpressCheckout\Api\Data\ExtraDetailInterface;
+use Adyen\ExpressCheckout\Api\Data\MethodResponseInterface;
+use Adyen\ExpressCheckout\Model\AdyenPaymentMethods;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(AdyenPaymentMethods::class)]
+final class AdyenPaymentMethodsTest extends AbstractAdyenTestCase
+{
+    private AdyenPaymentMethods $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new AdyenPaymentMethods();
+    }
+
+    #[Test]
+    public function get_extra_details_returns_empty_array_by_default(): void
+    {
+        $this->assertSame([], $this->subject->getExtraDetails());
+    }
+
+    #[Test]
+    public function get_methods_response_returns_empty_array_by_default(): void
+    {
+        $this->assertSame([], $this->subject->getMethodsResponse());
+    }
+
+    #[Test]
+    public function set_and_get_extra_details_round_trips(): void
+    {
+        /** @var ExtraDetailInterface&MockObject $d1 */
+        $d1 = $this->createMock(ExtraDetailInterface::class);
+        /** @var ExtraDetailInterface&MockObject $d2 */
+        $d2 = $this->createMock(ExtraDetailInterface::class);
+
+        $input = [$d1, $d2];
+
+        $this->subject->setExtraDetails($input);
+
+        $out = $this->subject->getExtraDetails();
+        $this->assertSame($input, $out);
+        $this->assertContainsOnlyInstancesOf(ExtraDetailInterface::class, $out);
+    }
+
+    #[Test]
+    public function set_and_get_methods_response_round_trips(): void
+    {
+        /** @var MethodResponseInterface&MockObject $m1 */
+        $m1 = $this->createMock(MethodResponseInterface::class);
+        /** @var MethodResponseInterface&MockObject $m2 */
+        $m2 = $this->createMock(MethodResponseInterface::class);
+
+        $input = [$m1, $m2];
+
+        $this->subject->setMethodsResponse($input);
+
+        $out = $this->subject->getMethodsResponse();
+        $this->assertSame($input, $out);
+        $this->assertContainsOnlyInstancesOf(MethodResponseInterface::class, $out);
+    }
+
+    #[Test]
+    public function get_extra_details_returns_empty_array_if_non_array_is_set_in_data_bag(): void
+    {
+        // Simulate foreign code putting unexpected scalar into the DataObject
+        $this->subject->setData(AdyenPaymentMethodsInterface::EXTRA_DETAILS, 'oops');
+
+        $this->assertSame([], $this->subject->getExtraDetails());
+    }
+
+    #[Test]
+    public function get_methods_response_returns_empty_array_if_non_array_is_set_in_data_bag(): void
+    {
+        // Simulate foreign code putting unexpected scalar into the DataObject
+        $this->subject->setData(AdyenPaymentMethodsInterface::METHODS_RESPONSE, 'oops');
+
+        $this->assertSame([], $this->subject->getMethodsResponse());
+    }
+}

--- a/Test/Unit/Model/ConfigurationTest.php
+++ b/Test/Unit/Model/ConfigurationTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model;
+
+use Adyen\ExpressCheckout\Model\Configuration;
+use Adyen\ExpressCheckout\Model\Config\Source\ApplePay\ButtonColor;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(Configuration::class)]
+class ConfigurationTest extends AbstractAdyenTestCase
+{
+    /** @var ScopeConfigInterface&MockObject */
+    private $scopeConfig;
+
+    private Configuration $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->subject = new Configuration($this->scopeConfig);
+    }
+
+    #[Test]
+    public function get_show_payment_method_on_returns_empty_array_when_config_missing(): void
+    {
+        $variant = 'paypal';
+        $path = sprintf(
+            '%s/%s_%s/%s',
+            Configuration::CONFIG_PATH_PAYMENT,
+            Configuration::CONFIG_PATH_ADYEN_PREFIX,
+            $variant,
+            Configuration::CONFIG_PATH_SHOW_EXPRESS_ON
+        );
+
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with($path, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn(null);
+
+        $this->assertSame([], $this->subject->getShowPaymentMethodOn($variant));
+    }
+
+    #[Test]
+    public function get_show_payment_method_on_returns_exploded_values_and_respects_scope(): void
+    {
+        $variant = 'applepay';
+        $scopeType = 'websites';
+        $scopeCode = 'nl';
+        $path = sprintf(
+            '%s/%s_%s/%s',
+            Configuration::CONFIG_PATH_PAYMENT,
+            Configuration::CONFIG_PATH_ADYEN_PREFIX,
+            $variant,
+            Configuration::CONFIG_PATH_SHOW_EXPRESS_ON
+        );
+
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with($path, $scopeType, $scopeCode)
+            ->willReturn('pdp,cart,checkout');
+
+        $this->assertSame(['pdp','cart','checkout'], $this->subject->getShowPaymentMethodOn(
+            $variant,
+            $scopeType,
+            $scopeCode
+        ));
+    }
+
+    #[Test]
+    public function get_apple_pay_button_color_returns_configured_value(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::APPLE_PAY_BUTTON_COLOR_CONFIG_PATH, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn(ButtonColor::WHITE);
+
+        $this->assertSame(ButtonColor::WHITE, $this->subject->getApplePayButtonColor());
+    }
+
+    #[Test]
+    public function get_apple_pay_button_color_defaults_to_black_when_empty(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::APPLE_PAY_BUTTON_COLOR_CONFIG_PATH, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn('');
+
+        $this->assertSame(ButtonColor::BLACK, $this->subject->getApplePayButtonColor());
+    }
+
+    #[Test]
+    public function get_show_apple_pay_on_returns_exploded_values(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::SHOW_APPLE_PAY_ON_CONFIG_PATH, ScopeInterface::SCOPE_STORE, 3)
+            ->willReturn('minicart,product');
+
+        $this->assertSame(['minicart','product'], $this->subject->getShowApplePayOn(
+            ScopeInterface::SCOPE_STORE,
+            3
+        ));
+    }
+
+    #[Test]
+    public function get_show_apple_pay_on_returns_empty_array_when_missing(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::SHOW_APPLE_PAY_ON_CONFIG_PATH, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn(null);
+
+        $this->assertSame([], $this->subject->getShowApplePayOn());
+    }
+
+    #[Test]
+    public function get_show_google_pay_on_returns_exploded_values(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::SHOW_GOOGLE_PAY_ON_CONFIG_PATH, 'websites', 'be')
+            ->willReturn('cart,checkout');
+
+        $this->assertSame(['cart','checkout'], $this->subject->getShowGooglePayOn('websites', 'be'));
+    }
+
+    #[Test]
+    public function get_show_google_pay_on_returns_empty_array_when_missing(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(Configuration::SHOW_GOOGLE_PAY_ON_CONFIG_PATH, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn('');
+
+        $this->assertSame([], $this->subject->getShowGooglePayOn());
+    }
+}

--- a/Test/Unit/Model/ExpressActivateTest.php
+++ b/Test/Unit/Model/ExpressActivateTest.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Model;
+
+use Adyen\ExpressCheckout\Model\ExpressActivate;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Api\Data\CartInterfaceFactory;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
+use Magento\Quote\Model\Quote as QuoteModel;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResourceModel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(ExpressActivate::class)]
+final class ExpressActivateTest extends AbstractAdyenTestCase
+{
+    /** @var CartRepositoryInterface&MockObject */
+    private $cartRepository;
+
+    /** @var CartInterfaceFactory&MockObject */
+    private $quoteFactory;
+
+    /** @var MaskedQuoteIdToQuoteIdInterface&MockObject */
+    private $maskedToId;
+
+    /** @var QuoteResourceModel&MockObject */
+    private $quoteResource;
+
+    private ExpressActivate $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+        $this->quoteFactory   = $this->createMock(CartInterfaceFactory::class);
+        $this->maskedToId     = $this->createMock(MaskedQuoteIdToQuoteIdInterface::class);
+        $this->quoteResource  = $this->createMock(QuoteResourceModel::class);
+
+        $this->subject = new ExpressActivate(
+            $this->quoteFactory,
+            $this->cartRepository,
+            $this->maskedToId,
+            $this->quoteResource
+        );
+    }
+
+    /** Adyen target quote (we only need setIsActive + custom getAdyenOgQuoteId) */
+    private function createAdyenQuoteMock(): QuoteModel&MockObject
+    {
+        return $this->getMockBuilder(QuoteModel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setIsActive'])
+            ->addMethods(['getAdyenOgQuoteId']) // method the model calls
+            ->getMock();
+    }
+
+    /** Current quote (we need getId + setIsActive) */
+    private function createCurrentQuoteMock(int $id): QuoteModel&MockObject
+    {
+        $q = $this->getMockBuilder(QuoteModel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'setIsActive'])
+            ->getMock();
+
+        $q->method('getId')->willReturn($id);
+        return $q;
+    }
+
+    #[Test]
+    public function it_deactivates_current_cart_and_activates_adyen_quote_when_cart_id_is_provided(): void
+    {
+        $maskedId = 'masked-xyz';
+        $resolvedId = 1001;
+        $currentCartId = 777;
+
+        $this->maskedToId->expects($this->once())
+            ->method('execute')
+            ->with($maskedId)
+            ->willReturn($resolvedId);
+
+        $adyenQuote = $this->createAdyenQuoteMock();
+        $this->quoteFactory->expects($this->once())->method('create')->willReturn($adyenQuote);
+
+        $this->quoteResource->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($adyenQuote), $resolvedId, CartInterface::KEY_ENTITY_ID);
+
+        $currentQuote = $this->createCurrentQuoteMock($currentCartId);
+
+        $currentQuote->expects($this->once())->method('setIsActive')->with(false);
+        $this->cartRepository->expects($this->once())->method('get')->with($currentCartId)->willReturn($currentQuote);
+
+        // Model calls: $adyenQuote->getAdyenOgQuoteId($currentQuote->getId());
+        $adyenQuote->expects($this->once())->method('getAdyenOgQuoteId')->with($currentCartId);
+
+        $saved = [];
+        $this->cartRepository->expects($this->exactly(2))
+            ->method('save')
+            ->willReturnCallback(function ($q) use (&$saved) { $saved[] = $q; return $q; });
+
+        $adyenQuote->expects($this->once())->method('setIsActive')->with(true);
+
+        $this->subject->execute($maskedId, $currentCartId);
+
+        $this->assertContains($currentQuote, $saved);
+        $this->assertContains($adyenQuote, $saved);
+        $this->assertCount(2, $saved);
+    }
+
+    #[Test]
+    public function it_activates_adyen_quote_when_current_cart_not_found(): void
+    {
+        $maskedId = 'masked-abc';
+        $resolvedId = 2002;
+        $currentCartId = 888;
+
+        $this->maskedToId->method('execute')->with($maskedId)->willReturn($resolvedId);
+
+        $adyenQuote = $this->createAdyenQuoteMock();
+        $this->quoteFactory->method('create')->willReturn($adyenQuote);
+
+        $this->quoteResource->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($adyenQuote), $resolvedId, CartInterface::KEY_ENTITY_ID);
+
+        $this->cartRepository->method('get')->with($currentCartId)
+            ->willThrowException(new NoSuchEntityException(__('no such cart')));
+
+        $adyenQuote->expects($this->never())->method('getAdyenOgQuoteId');
+        $adyenQuote->expects($this->once())->method('setIsActive')->with(true);
+
+        $this->cartRepository->expects($this->once())->method('save')->with($adyenQuote);
+
+        $this->subject->execute($maskedId, $currentCartId);
+    }
+
+    #[Test]
+    public function it_activates_adyen_quote_when_no_current_cart_id_is_provided(): void
+    {
+        $maskedId = 'masked-no-cart';
+        $resolvedId = 3003;
+
+        $this->maskedToId->method('execute')->with($maskedId)->willReturn($resolvedId);
+
+        $adyenQuote = $this->createAdyenQuoteMock();
+        $this->quoteFactory->method('create')->willReturn($adyenQuote);
+
+        $this->quoteResource->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($adyenQuote), $resolvedId, CartInterface::KEY_ENTITY_ID);
+
+        $this->cartRepository->expects($this->never())->method('get');
+
+        $adyenQuote->expects($this->once())->method('setIsActive')->with(true);
+        $this->cartRepository->expects($this->once())->method('save')->with($adyenQuote);
+
+        $this->subject->execute($maskedId, null);
+    }
+
+    #[Test]
+    public function it_throws_no_such_entity_when_masked_id_resolution_fails(): void
+    {
+        $this->maskedToId->method('execute')
+            ->with('bad-masked')
+            ->willThrowException(new NoSuchEntityException(__('missing')));
+
+        $this->quoteFactory->expects($this->never())->method('create');
+        $this->quoteResource->expects($this->never())->method('load');
+        $this->cartRepository->expects($this->never())->method('save');
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage('Could not find a cart with ID');
+
+        $this->subject->execute('bad-masked', null);
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR refactors the unit tests to support PHPUnit v10. In the scope of refactoring,

- Unit test pipeline main.yml has been revisited to run PHPUnit according to Magento best practices.
- Some test cases have been added/updated.




