### PR TITLE
[ECP-9629] Add lineItems to PayPal express /payments request

### DIFF
--- a/Helper/LineItemsDataBuilder.php
+++ b/Helper/LineItemsDataBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Adyen\ExpressCheckout\Helper;
+
+use Adyen\Payment\Helper\OpenInvoice;
+use Magento\Quote\Model\Quote;
+
+class LineItemsDataBuilder extends OpenInvoice
+{
+    public function getOpenInvoiceDataForQuote(Quote $cart): array
+    {
+        $formFields = ['lineItems' => []];
+
+        foreach ($cart->getAllVisibleItems() as $item) {
+            $itemAmountCurrency = $this->chargedCurrency->getQuoteItemAmountCurrency($item);
+            $formFields['lineItems'][] = $this->formatLineItem($itemAmountCurrency, $item);
+        }
+
+        return $formFields;
+    }
+}

--- a/Test/Unit/Helper/LineItemsDataBuilderTest.php
+++ b/Test/Unit/Helper/LineItemsDataBuilderTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Test\Unit\Helper;
+
+use Adyen\ExpressCheckout\Helper\LineItemsDataBuilder;
+use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Adyen\Payment\Model\AdyenAmountCurrency;
+
+class LineItemsDataBuilderTest extends AbstractAdyenTestCase
+{
+    /** @var LineItemsDataBuilder&\PHPUnit\Framework\MockObject\MockObject */
+    private $builder;
+
+    /** @var ChargedCurrency&\PHPUnit\Framework\MockObject\MockObject */
+    private $chargedCurrency;
+
+    protected function setUp(): void
+    {
+        $this->builder = $this->getMockBuilder(LineItemsDataBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['formatLineItem'])
+            ->getMock();
+
+        $this->chargedCurrency = $this->createMock(ChargedCurrency::class);
+        $refClass = new \ReflectionClass($this->builder);
+        $parent = $refClass->getParentClass(); // OpenInvoice
+        $prop = $parent->getProperty('chargedCurrency');
+        $prop->setAccessible(true);
+        $prop->setValue($this->builder, $this->chargedCurrency);
+    }
+
+    public function testReturnsEmptyArrayWhenNoVisibleItems(): void
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([]);
+
+        $this->chargedCurrency->expects($this->never())->method('getQuoteItemAmountCurrency');
+        $this->builder->expects($this->never())->method('formatLineItem');
+
+        $result = $this->builder->getOpenInvoiceDataForQuote($quote);
+
+        $this->assertSame(['lineItems' => []], $result);
+    }
+
+    public function testBuildsSingleLineItem(): void
+    {
+        $item1  = $this->createMock(Item::class);
+        $quote  = $this->createMock(Quote::class);
+        $amount = $this->createMock(AdyenAmountCurrency::class);
+
+        $quote->method('getAllVisibleItems')->willReturn([$item1]);
+
+        $this->chargedCurrency->expects($this->once())
+            ->method('getQuoteItemAmountCurrency')
+            ->with($item1)
+            ->willReturn($amount);
+
+        $this->builder->expects($this->once())
+            ->method('formatLineItem')
+            ->with($amount, $item1)
+            ->willReturn(['id' => 'SKU-1', 'amountIncludingTax' => 1000]);
+
+        $result = $this->builder->getOpenInvoiceDataForQuote($quote);
+
+        $this->assertEquals(
+            ['lineItems' => [['id' => 'SKU-1', 'amountIncludingTax' => 1000]]],
+            $result
+        );
+    }
+
+    public function testBuildsMultipleLineItemsPreservingOrder(): void
+    {
+        $item1   = $this->createMock(Item::class);
+        $item2   = $this->createMock(Item::class);
+        $quote   = $this->createMock(Quote::class);
+        $amount1 = $this->createMock(AdyenAmountCurrency::class);
+        $amount2 = $this->createMock(AdyenAmountCurrency::class);
+
+        $quote->method('getAllVisibleItems')->willReturn([$item1, $item2]);
+
+        $this->chargedCurrency->method('getQuoteItemAmountCurrency')
+            ->willReturnMap([
+                [$item1, $amount1],
+                [$item2, $amount2],
+            ]);
+
+        $result = $this->builder->getOpenInvoiceDataForQuote($quote);
+
+        // top-level array with "lineItems"
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('lineItems', $result);
+        $this->assertIsArray($result['lineItems']);
+
+        // exactly 2 items, in list order (0,1)
+        $this->assertCount(2, $result['lineItems']);
+        $this->assertSame([0, 1], array_keys($result['lineItems']));
+
+        // each item is an array (don’t care about the keys/values)
+        $this->assertContainsOnly('array', $result['lineItems']);
+    }
+}

--- a/Test/Unit/Model/AdyenInitPaymentsTest.php
+++ b/Test/Unit/Model/AdyenInitPaymentsTest.php
@@ -1,74 +1,304 @@
 <?php
 /**
- * PHPUnit Test for AdyenInitPayments
+ * PHPUnit Test for AdyenInitPayments (updated)
  */
 declare(strict_types=1);
 
 namespace Adyen\ExpressCheckout\Test\Unit\Model;
 
+use Adyen\ExpressCheckout\Helper\LineItemsDataBuilder;
 use Adyen\ExpressCheckout\Model\AdyenInitPayments;
 use Adyen\Payment\Gateway\Http\Client\TransactionPayment;
 use Adyen\Payment\Gateway\Http\TransferFactory;
+use Adyen\Payment\Gateway\Request\Header\HeaderDataBuilderInterface;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\PaymentResponseHandler;
+use Adyen\Payment\Helper\Requests;
 use Adyen\Payment\Helper\ReturnUrlHelper;
 use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
 use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\ValidatorException;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Helper\Data as DataHelper;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
-use Adyen\Payment\Helper\Requests;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class AdyenInitPaymentsTest extends AbstractAdyenTestCase
 {
     private AdyenInitPayments $adyenInitPayments;
-    private CartRepositoryInterface $cartRepository;
+
+    // Core deps
     private CheckoutStateDataValidator $checkoutStateDataValidator;
     private TransferFactory $transferFactory;
     private TransactionPayment $transactionPaymentClient;
     private PaymentResponseHandler $paymentResponseHandler;
-    private QuoteIdMaskFactory $quoteIdMaskFactoryMock;
+    private QuoteIdMaskFactory $quoteIdMaskFactory;
     private Vault $vaultHelper;
+    private UserContextInterface $userContext;
     private Requests $requestHelper;
+    private PaymentMethods $paymentMethodsHelper;
+    private DataHelper $dataHelper;
+    private LineItemsDataBuilder $lineItemsDataBuilder;
+    private Quote|MockObject $quote;
 
+    private TransferInterface $transferMock;
+
+    private string $stateData;
+    private array $headers;
+
+    /**
+     * @throws \JsonException
+     */
     protected function setUp(): void
     {
-        $this->transferMock = $this->createMock(\Magento\Payment\Gateway\Http\TransferInterface::class);
-        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+        // Mocks
+        $this->transferMock = $this->createMock(TransferInterface::class);
+
+        $this->quote = $this->createMockWithMethods(
+            Quote::class,
+            [
+                'getStoreId',
+                'getReservedOrderId',
+                'reserveOrderId'
+            ],
+            [
+                'getSubtotalWithDiscount',
+                'getQuoteCurrencyCode'
+            ]
+        );
+
+        $this->mockMethods($this->quote,
+            [
+                'getSubtotalWithDiscount' => 123.45,
+                'getQuoteCurrencyCode' => 'EUR',
+                'getStoreId' => 1,
+                'getReservedOrderId' => '1000001'
+            ]
+        );
+
+        $cartRepository = $this->createMock(CartRepositoryInterface::class);
         $configHelper = $this->createMock(Config::class);
         $returnUrlHelper = $this->createMock(ReturnUrlHelper::class);
         $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
         $this->transferFactory = $this->createMock(TransferFactory::class);
         $this->transactionPaymentClient = $this->createMock(TransactionPayment::class);
-        $this->adyenHelper = $this->createMock(Data::class);
-        $this->vaultHelper = $this->createConfiguredMock(Vault::class, [
-            'getPaymentMethodRecurringActive' => true,
-            'getPaymentMethodRecurringProcessingModel' => 'CardOnFile'
-        ]);
-        $this->requestHelper = $this->createMock(Requests::class);
+        $adyenHelper = $this->createMock(Data::class);
         $this->paymentResponseHandler = $this->createMock(PaymentResponseHandler::class);
-        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(
-            QuoteIdMaskFactory::class,
-            ['create']
-        );
-        $this->quoteIdMaskMock = $this->createMock(QuoteIdMask::class);
-        $this->quoteIdMaskFactoryMock->method('create')->willReturn($this->quoteIdMaskMock);
+        $this->quoteIdMaskFactory = $this->createGeneratedMock(QuoteIdMaskFactory::class, ['create']);
+        $this->vaultHelper = $this->createMock(Vault::class);
         $this->userContext = $this->createMock(UserContextInterface::class);
-        $requestHelper = $this->createMock(Requests::class);
-        $this->quote = $this->createMock(Quote::class);
+        $this->requestHelper = $this->createMock(Requests::class);
+        $this->paymentMethodsHelper = $this->createMock(PaymentMethods::class);
+        $this->dataHelper = $this->createMock(DataHelper::class);
+        $this->lineItemsDataBuilder = $this->createMock(LineItemsDataBuilder::class);
 
-        $this->quote->method('getReservedOrderId')->willReturn('1000001');
-        $this->paymentsRequest = [
-            'amount' => [
-                'currency' => null,
-                'value' => null
+        $cartRepository
+            ->method('get')
+            ->willReturn($this->quote);
+
+        $cartRepository->expects($this->once())->method('save')->with($this->quote);
+
+        // Config & helpers used in buildPaymentsRequest
+        $configHelper->method('getMerchantAccount')->with(1)->willReturn('TestMerchant');
+        $returnUrlHelper->method('getStoreReturnUrl')->with(1)->willReturn('');
+        $adyenHelper->method('formatAmount')->with(123.45, 'EUR')->willReturn(12345);
+
+        // Request headers: we append FRONTEND_TYPE in the class; base headers from helper
+        $this->headers = [
+            'external-platform-name' => 'magento',
+            'external-platform-version' => '2.x.x',
+            'external-platform-edition' => 'Community',
+            'merchant-application-name' => 'adyen-magento2',
+            'merchant-application-version' => '1.2.3',
+        ];
+        $adyenHelper->method('buildRequestHeaders')->willReturn($this->headers);
+
+        // Default: guest user
+        $this->userContext->method('getUserType')->willReturn(UserContextInterface::USER_TYPE_GUEST);
+        $this->userContext->method('getUserId')->willReturn(null);
+
+        // Payment method instance + no line items required by default
+        $methodInstance = $this->createMock(\Magento\Payment\Model\MethodInterface::class);
+        $this->dataHelper->method('getMethodInstance')->with('adyen_paypal')->willReturn($methodInstance);
+        $this->paymentMethodsHelper->method('getRequiresLineItems')->with($methodInstance)->willReturn(false);
+
+        // State data fixture (valid PayPal)
+        $this->stateData = json_encode([
+            'paymentMethod' => [
+                'type' => 'paypal',
+                'userAction' => 'pay',
+                'subtype' => 'express',
+                'checkoutAttemptId' => '3'
             ],
+            'clientStateDataIndicator' => true,
+            'merchantAccount' => 'TestMerchant'
+        ], JSON_THROW_ON_ERROR);
+
+        // SUT
+        $this->adyenInitPayments = new AdyenInitPayments(
+            $cartRepository,
+            $configHelper,
+            $returnUrlHelper,
+            $this->checkoutStateDataValidator,
+            $this->transferFactory,
+            $this->transactionPaymentClient,
+            $adyenHelper,
+            $this->paymentResponseHandler,
+            $this->quoteIdMaskFactory,
+            $this->vaultHelper,
+            $this->userContext,
+            $this->requestHelper,
+            $this->paymentMethodsHelper,
+            $this->dataHelper,
+            $this->lineItemsDataBuilder
+        );
+    }
+
+    private function mockMethods(MockObject $object, $methods): void
+    {
+        foreach ($methods as $method => $return) {
+            $object->method($method)->willReturn($return);
+        }
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws ClientException
+     */
+    public function testExecuteThrowsExceptionForInvalidJson(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->adyenInitPayments->execute('{invalidJson}', 1);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws \JsonException
+     * @throws ClientException
+     */
+    public function testExecuteThrowsExceptionForInvalidPaymentMethod(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $bad = json_encode(['paymentMethod' => ['type' => 'creditcard']], JSON_THROW_ON_ERROR);
+        $this->adyenInitPayments->execute($bad, 1);
+    }
+
+    public function testExecuteHandlesClientException(): void
+    {
+        // Validate & pass through the stateData
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
+
+        // Expect transfer created with our computed body and headers (including frontend type)
+        $expectedHeaders = $this->headers;
+        $expectedHeaders[HeaderDataBuilderInterface::EXTERNAL_PLATFORM_FRONTEND_TYPE] = 'default';
+
+        $expectedBody = [
+            'amount' => ['currency' => 'EUR', 'value' => 12345],
+            'reference' => '1000001',
+            'returnUrl' => '?merchantReference=1000001',
+            'merchantAccount' => 'TestMerchant',
+            'channel' => 'web',
+            'paymentMethod' => [
+                'type' => 'paypal',
+                'userAction' => 'pay',
+                'subtype' => 'express',
+                'checkoutAttemptId' => '3'
+            ],
+            'clientStateDataIndicator' => true,
+        ];
+
+        $this->transferFactory->expects($this->once())->method('create')->with([
+            'body' => $expectedBody,
+            'clientConfig' => ['storeId' => 1],
+            'headers' => $expectedHeaders
+        ])->willReturn($this->transferMock);
+
+        // Simulate lower-level failure -> class should throw Magento ClientException
+        $this->transactionPaymentClient->method('placeRequest')
+            ->willThrowException(new LocalizedException(__('Error with payment method, please select a different payment method!')));
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Error with payment method, please select a different payment method!');
+
+        $this->adyenInitPayments->execute($this->stateData, 1);
+    }
+
+    public function testExecuteHandlesSuccessfulPayment(): void
+    {
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
+
+        $expectedHeaders = $this->headers;
+        $expectedHeaders[HeaderDataBuilderInterface::EXTERNAL_PLATFORM_FRONTEND_TYPE] = 'default';
+
+        $expectedBody = [
+            'amount' => ['currency' => 'EUR', 'value' => 12345],
+            'reference' => '1000001',
+            'returnUrl' => '?merchantReference=1000001',
+            'merchantAccount' => 'TestMerchant',
+            'channel' => 'web',
+            'paymentMethod' => [
+                'type' => 'paypal',
+                'userAction' => 'pay',
+                'subtype' => 'express',
+                'checkoutAttemptId' => '3'
+            ],
+            'clientStateDataIndicator' => true,
+        ];
+
+        $this->transferFactory->method('create')->with([
+            'body' => $expectedBody,
+            'clientConfig' => ['storeId' => 1],
+            'headers' => $expectedHeaders
+        ])->willReturn($this->transferMock);
+
+        $this->transactionPaymentClient->method('placeRequest')->willReturn([
+            ['resultCode' => 'Authorised', 'action' => null]
+        ]);
+
+        $this->paymentResponseHandler->method('formatPaymentResponse')
+            ->with('Authorised', null)
+            ->willReturn(['status' => 'success']);
+
+        $response = $this->adyenInitPayments->execute($this->stateData, 1);
+
+        $this->assertJson($response);
+        $this->assertStringContainsString('success', $response);
+    }
+
+    public function testExecuteHandlesLoggedInUserWithRecurring(): void
+    {
+        // Logged in
+        $this->userContext->method('getUserType')->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
+        $this->userContext->method('getUserId')->willReturn(12345);
+
+        // Vault enabled and CoF model
+        $this->vaultHelper->method('getPaymentMethodRecurringActive')->with('adyen_paypal', 1)->willReturn(true);
+        $this->vaultHelper->method('getPaymentMethodRecurringProcessingModel')->with('adyen_paypal', 1)->willReturn('CardOnFile');
+        $this->requestHelper->method('getShopperReference')->with(12345, null)->willReturn('12345');
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
+
+        $expectedHeaders = $this->headers;
+        $expectedHeaders[HeaderDataBuilderInterface::EXTERNAL_PLATFORM_FRONTEND_TYPE] = 'default';
+
+        $expectedBody = [
+            'amount' => ['currency' => 'EUR', 'value' => 12345],
             'reference' => '1000001',
             'returnUrl' => '?merchantReference=1000001',
             'merchantAccount' => 'TestMerchant',
@@ -82,11 +312,39 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
             'clientStateDataIndicator' => true
         ];
 
-        $this->paymentsRequestLoggedInUser = [
-            'amount' => [
-                'currency' => null,
-                'value' => null
-            ],
+        $this->transferFactory->expects($this->once())->method('create')->with([
+            'body' => $expectedBody,
+            'clientConfig' => ['storeId' => 1],
+            'headers' => $expectedHeaders
+        ])->willReturn($this->transferMock);
+
+        $this->transactionPaymentClient->method('placeRequest')->willReturn([
+            ['resultCode' => 'Authorised', 'action' => null]
+        ]);
+
+        $this->paymentResponseHandler->method('formatPaymentResponse')->willReturn(['status' => 'success']);
+
+        $response = $this->adyenInitPayments->execute($this->stateData, 1);
+
+        $this->assertJson($response);
+        $this->assertStringContainsString('success', $response);
+    }
+
+    public function testExecuteHandlesMaskedQuoteId(): void
+    {
+        $mask = $this->createGeneratedMock(QuoteIdMask::class, ['load', 'getQuoteId']);
+        $mask->expects($this->once())->method('load')->with('masked123', 'masked_id')->willReturn($mask);
+        $mask->expects($this->once())->method('getQuoteId')->willReturn(99);
+        $this->quoteIdMaskFactory->method('create')->willReturn($mask);
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
+
+        $expectedHeaders = $this->headers;
+        $expectedHeaders[HeaderDataBuilderInterface::EXTERNAL_PLATFORM_FRONTEND_TYPE] = 'default';
+
+        $expectedBody = [
+            'amount' => ['currency' => 'EUR', 'value' => 12345],
             'reference' => '1000001',
             'returnUrl' => '?merchantReference=1000001',
             'merchantAccount' => 'TestMerchant',
@@ -98,94 +356,13 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
                 'checkoutAttemptId' => '3'
             ],
             'clientStateDataIndicator' => true,
-            'storePaymentMethod' => true,
-            'shopperReference' => '',
-            'shopperInteraction' => 'Ecommerce',
-            'recurringProcessingModel' => 'CardOnFile'
         ];
 
-        $this->headers = [
-            'external-platform-name' => 'magento',
-            'external-platform-version' => '2.x.x',
-            'external-platform-edition' => 'Community',
-            'merchant-application-name' => 'adyen-magento2',
-            'merchant-application-version' => '1.2.3',
-            'external-platform-frontendtype' => 'default'
-        ];
-        $this->adyenInitPayments = new AdyenInitPayments(
-            $this->cartRepository,
-            $configHelper,
-            $returnUrlHelper,
-            $this->checkoutStateDataValidator,
-            $this->transferFactory,
-            $this->transactionPaymentClient,
-            $this->adyenHelper,
-            $this->paymentResponseHandler,
-            $this->quoteIdMaskFactoryMock,
-            $this->vaultHelper,
-            $this->userContext,
-            $requestHelper
-        );
-
-        $this->stateData = '{"paymentMethod":{"type":"paypal","userAction":"pay","subtype":"express","checkoutAttemptId":"3"},"clientStateDataIndicator":true,"merchantAccount":"TestMerchant"}';
-
-    }
-
-    public function testExecuteThrowsExceptionForInvalidJson(): void
-    {
-        $this->cartRepository->method('get')->willReturn($this->quote);
-        $this->expectException(ValidatorException::class);
-        $this->adyenInitPayments->execute('{invalidJson}', 1);
-    }
-
-    public function testExecuteThrowsExceptionForInvalidPaymentMethod(): void
-    {
-        $this->cartRepository->method('get')->willReturn($this->quote);
-        $this->expectException(ValidatorException::class);
-        $this->adyenInitPayments->execute(json_encode(['paymentMethod' => ['type' => 'creditcard']]), 1);
-    }
-
-    public function testExecuteHandlesClientException(): void
-    {
-
-        $this->cartRepository->method('get')->willReturn($this->quote);
-        $this->checkoutStateDataValidator->expects($this->once())
-            ->method('getValidatedAdditionalData')
-            ->willReturn(json_decode($this->stateData, true));
-        $this->adyenHelper->method('buildRequestHeaders')
-            ->willReturn($this->headers);
-        $this->transferFactory->expects($this->once())
-            ->method('create')
-            ->with([
-                'body' => $this->paymentsRequest,
-                'clientConfig' => ['storeId' => $this->quote->getStoreId()],
-                'headers' => $this->headers
-            ])
-            ->willReturn($this->transferMock);
-
-        $this->transactionPaymentClient->method('placeRequest')
-            ->willThrowException(new LocalizedException(__('Error with payment method, please select a different payment method!')));
-
-        $this->expectException(LocalizedException::class);
-        $this->expectExceptionMessage('Error with payment method, please select a different payment method!');
-
-        // Call the method to test exception handling
-        $this->adyenInitPayments->execute($this->stateData, 1);
-    }
-
-    public function testExecuteHandlesSuccessfulPayment()
-    {
-        $this->cartRepository->method('get')->willReturn($this->quote);
-
-        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn(json_decode($this->stateData, true));
-        $this->adyenHelper->method('buildRequestHeaders')
-            ->willReturn($this->headers);
         $this->transferFactory->method('create')->with([
-            'body' => $this->paymentsRequest,
-            'clientConfig' => ['storeId' => $this->quote->getStoreId()],
-            'headers' => $this->headers
-        ])
-            ->willReturn($this->transferMock);
+            'body' => $expectedBody,
+            'clientConfig' => ['storeId' => 1],
+            'headers' => $expectedHeaders
+        ])->willReturn($this->transferMock);
 
         $this->transactionPaymentClient->method('placeRequest')->willReturn([
             ['resultCode' => 'Authorised', 'action' => null]
@@ -193,99 +370,84 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
 
         $this->paymentResponseHandler->method('formatPaymentResponse')->willReturn(['status' => 'success']);
 
-        $response = $this->adyenInitPayments->execute($this->stateData, 1);
-
+        $response = $this->adyenInitPayments->execute($this->stateData, null, 'masked123');
         $this->assertJson($response);
-        $this->assertStringContainsString('success', $response);
     }
 
-    public function testExecuteHandlesLoggedInUser(): void
+    public function testAddsLineItemsWhenRequired(): void
     {
-        $customerId = 12345;
-        $this->cartRepository->method('get')->willReturn($this->quote);
-        $paymentMethodCode = 'adyen_paypal';
-        $storeId = $this->quote
-            ->method('getStoreId')
-            ->willReturn(1);
-        $this->userContext->expects($this->once())
-            ->method('getUserType')
-            ->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
+        // Make method require line items
+        $methodInstance = $this->createMock(\Magento\Payment\Model\MethodInterface::class);
+        $this->dataHelper->method('getMethodInstance')->with('adyen_paypal')->willReturn($methodInstance);
+        $this->paymentMethodsHelper->method('getRequiresLineItems')->with($methodInstance)->willReturn(true);
 
-        $this->userContext->expects($this->once())
-            ->method('getUserId')
-            ->willReturn($customerId);
+        // Return line items + amountUpdates (typical OpenInvoice data builder output)
+        $invoiceData = [
+            'lineItems' => [
+                ['id' => 'sku-1', 'quantity' => 1, 'amountIncludingTax' => 12345]
+            ],
+            'countryCode' => 'NL'
+        ];
+        $this->lineItemsDataBuilder->method('getOpenInvoiceDataForQuote')->with($this->quote)->willReturn($invoiceData);
 
         $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
-            ->willReturn(json_decode($this->stateData, true)
-        );
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
 
-        // Mock RequestHelper method
-        $this->requestHelper
-            ->method('getShopperReference')
-            ->with($customerId, null)
-            ->willReturn('12345');
+        $expectedHeaders = $this->headers;
+        $expectedHeaders[HeaderDataBuilderInterface::EXTERNAL_PLATFORM_FRONTEND_TYPE] = 'default';
 
-        $this->adyenHelper->method('buildRequestHeaders')
-            ->willReturn($this->headers);
+        $expectedBody = [
+            'amount' => ['currency' => 'EUR', 'value' => 12345],
+            'reference' => '1000001',
+            'returnUrl' => '?merchantReference=1000001',
+            'merchantAccount' => 'TestMerchant',
+            'channel' => 'web',
+            'paymentMethod' => [
+                'type' => 'paypal',
+                'userAction' => 'pay',
+                'subtype' => 'express',
+                'checkoutAttemptId' => '3'
+            ],
+            'clientStateDataIndicator' => true
+        ];
 
-        $this->transferFactory->method('create')->with([
-            'body' => $this->paymentsRequestLoggedInUser,
-            'clientConfig' => ['storeId' => $this->quote->getStoreId()],
-            'headers' => $this->headers
-        ])
-            ->willReturn($this->transferMock);
+        $this->transferFactory->expects($this->once())->method('create')->with([
+            'body' => $expectedBody,
+            'clientConfig' => ['storeId' => 1],
+            'headers' => $expectedHeaders
+        ])->willReturn($this->transferMock);
 
         $this->transactionPaymentClient->method('placeRequest')->willReturn([
             ['resultCode' => 'Authorised', 'action' => null]
         ]);
-
         $this->paymentResponseHandler->method('formatPaymentResponse')->willReturn(['status' => 'success']);
 
         $response = $this->adyenInitPayments->execute($this->stateData, 1);
-
         $this->assertJson($response);
         $this->assertStringContainsString('success', $response);
     }
 
-    public function testExecuteHandlesMaskedQuoteId()
+    public function testCleansGiftCardWrapperResponse(): void
     {
-        $adyenMaskedQuoteId = '231';
-        $expectedQuoteId = 99;
-
-        $this->quoteIdMaskMock->expects($this->once())
-            ->method('load')
-            ->with($adyenMaskedQuoteId, 'masked_id')
-            ->willReturn($this->quoteIdMaskMock);
-
-
-        $this->quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, ['load', 'getQuoteId']);
-        $this->quoteIdMaskMock->method('load')->willReturn($this->quoteIdMaskMock);
-        $this->quoteIdMaskMock->method('getQuoteId')->willReturn($expectedQuoteId);
-
-        $this->cartRepository->method('get')->willReturn($this->quote);
         $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
-            ->willReturn(json_decode($this->stateData, true)
-            );
+            ->willReturn(json_decode($this->stateData, true, 512, JSON_THROW_ON_ERROR));
 
-        $this->adyenHelper->method('buildRequestHeaders')
-            ->willReturn($this->headers);
+        // We don’t assert the exact body/headers again here
+        $this->transferFactory->method('create')->willReturn($this->transferMock);
 
-        $this->transferFactory->method('create')->with([
-            'body' => $this->paymentsRequest,
-            'clientConfig' => ['storeId' => $this->quote->getStoreId()],
-            'headers' => $this->headers
-        ])
-            ->willReturn($this->transferMock);
-
+        // Simulate the "gift card wrapper": hasOnlyGiftCards plus the first element being the real payments response
         $this->transactionPaymentClient->method('placeRequest')->willReturn([
-            ['resultCode' => 'Authorised', 'action' => null]
+            'hasOnlyGiftCards' => true,
+            ['resultCode' => 'Pending', 'action' => ['type' => 'redirect']]
         ]);
 
+        $this->paymentResponseHandler->method('formatPaymentResponse')
+            ->with('Pending', ['type' => 'redirect'])
+            ->willReturn(['status' => 'pending']);
 
-        // Call the method under test
-        $response = $this->adyenInitPayments->execute($this->stateData, null, $adyenMaskedQuoteId);
+        $response = $this->adyenInitPayments->execute($this->stateData, 1);
 
         $this->assertJson($response);
+        $this->assertStringContainsString('pending', $response);
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "adyen/module-payment": "^9.8.1"
+    "adyen/module-payment": "^9.16.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~9.6.1",

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -35,6 +35,7 @@
                 <supports_recurring>0</supports_recurring>
                 <supports_manual_capture>1</supports_manual_capture>
                 <supports_auto_capture>1</supports_auto_capture>
+                <requires_line_items>1</requires_line_items>
                 <is_wallet>0</is_wallet>
                 <group>adyen-express-payment-method</group>
             </adyen_paypal_express>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR aims at setting `requires_line_items` configuration field to `true` for PayPal Express, then adding the `LineItems` in the `/payments` requests for Paypal Express.

