### PR TITLE
[ECP-9845] Apple Pay merchant name is incorrectly populated for main-2

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -259,7 +259,7 @@ define([
                 applepayBaseConfiguration = {
                     countryCode: countryCode,
                     currencyCode: currency,
-                    totalPriceLabel: this.getMerchantName(),
+                    totalPriceLabel: applePaymentMethod.configuration.merchantName,
                     configuration: {
                         domainName: window.location.hostname,
                         merchantId: applePaymentMethod.configuration.merchantId,


### PR DESCRIPTION
## Summary
After enabling ADB **checkoutUseApplePayAcquirerMerchantName**, Apple Pay modal should show the name defined in the acquirer account's merchantName property.

This has been controlled by totalPriceLabel field of the component configuration and this field should be populated from the `configuration.merchantName` field.

This PR aims to solve the issue persisting only on the Express checkout where we now show the configured value for the Merchant Account.