### PR TITLE
[ECP-9836] Hide Apple Pay wrapper on unsupported devices

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -203,7 +203,7 @@ define([
             },
 
             /**
-             * @param {*} error
+             * @param {HTMLElement} element
              */
             onNotAvailable: function (element) {
                 console.log('Apple pay is unavailable.');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR removes the empty Apple Pay wrapper on unsupported devices.

## Tested scenarios
<!-- Description of tested scenarios -->
- Apple Pay checkout on Android device