### PR TITLE
[ECP-9866-V2] Fix 3DS2 modal not appearing on retry for Google Pay Express Checkout

### DIFF
--- a/view/frontend/templates/action-container.phtml
+++ b/view/frontend/templates/action-container.phtml
@@ -1,3 +1,7 @@
 <?php /** @var $block \Magento\Framework\View\Element\Template */ ?>
 
-<div id="adyen-checkout-action_modal"></div>
+<div id="adyen-checkout-action_modalWrapper">
+    <div id="adyen-checkout-action_modal">
+        <div id="adyen-checkout-action_modalContent"></div>
+    </div>
+</div>

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -38,7 +38,8 @@ define([
     'Adyen_ExpressCheckout/js/model/currency',
     'Adyen_ExpressCheckout/js/model/virtualQuote',
     'Adyen_ExpressCheckout/js/helpers/getCurrentPage',
-    'Adyen_ExpressCheckout/js/model/adyen-loader'
+    'Adyen_ExpressCheckout/js/model/adyen-loader',
+    'Magento_Checkout/js/model/error-processor'
 ],
     function (
         $,
@@ -80,7 +81,8 @@ define([
         currencyModel,
         virtualQuoteModel,
         getCurrentPage,
-        loader
+        loader,
+        errorProcessor
     ) {
         'use strict';
 
@@ -552,6 +554,7 @@ define([
             handleAction: function(action, orderId) {
                 var self = this;
                 let popupModal;
+                let actionNode = document.getElementById(this.modalLabel + 'Content');
 
                 if (action.type === 'threeDS2' || action.type === 'await') {
                     popupModal = self.showModal();
@@ -565,7 +568,7 @@ define([
                                 popupModal.modal('openModal');
                             }
                         }
-                    }).mount('#' + this.modalLabel);
+                    }).mount(actionNode);
                 } catch (e) {
                     console.log(e);
                     loader.stopLoader();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR Fixes an issue where the 3DS2 authentication modal failed to appear on subsequent Google Pay Express payment attempts. Adds a wrapper to the action-container template and updates handleAction to mount actions to the content element.
