### PR TITLE
[ECP-9865] Unable to Promote Paypal Express Offers to Payment

### DIFF
--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -182,21 +182,11 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
             $paymentsResponse = $this->returnFirstTransactionPaymentResponse($response);
             $quotePayment = $quote->getPayment();
             if ($quotePayment) {
-                $quotePayment->setAdditionalInformation('resultCode', $paymentsResponse['resultCode'] ?? null);
-
-                // (Optional but often useful) store pspReference too if present
-                if (!empty($paymentsResponse['pspReference'])) {
-                    $quotePayment->setAdditionalInformation('pspReference', $paymentsResponse['pspReference']);
-                }
-
-                if (!empty($paymentsResponse['action'])) {
-                    $quotePayment->setAdditionalInformation('action', $paymentsResponse['action']);
-                }
-                if (!empty($paymentsResponse['additionalData'])) {
-                    $quotePayment->setAdditionalInformation('additionalData', $paymentsResponse['additionalData']);
-                }
-                if (!empty($paymentsResponse['details'])) {
-                    $quotePayment->setAdditionalInformation('details', $paymentsResponse['details']);
+                $fieldsToStore = ['resultCode','pspReference', 'action', 'additionalData', 'details'];
+                foreach ($fieldsToStore as $field) {
+                    if (!empty($paymentsResponse[$field])) {
+                        $quotePayment->setAdditionalInformation($field, $paymentsResponse[$field]);
+                    }
                 }
             }
 

--- a/Test/Unit/Model/AdyenInitPaymentsTest.php
+++ b/Test/Unit/Model/AdyenInitPaymentsTest.php
@@ -403,13 +403,19 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
         $this->assertStringContainsString('ok-with-lines', $resp);
     }
 
-    public function testExecuteSetsAdditionalInformationOnQuotePaymentWithAllFields(): void
-    {
+    /**
+     * @dataProvider additionalInformationProvider
+     */
+    public function testExecuteSetsAdditionalInformationFromPaymentsResponse(
+        array $paymentsResponse,
+        array $expectedAdditionalInformationCalls,
+        array $expectedFormatPaymentResponseArgs,
+        string $expectedStatus
+    ): void {
         $paymentMock = $this->createMock(\Magento\Quote\Model\Quote\Payment::class);
 
         $this->quote->method('reserveOrderId')->willReturnSelf();
         $this->cartRepository->method('get')->willReturn($this->quote);
-
         $this->cartRepository->expects($this->exactly(2))->method('save')->with($this->quote);
 
         $this->quote->method('getStoreId')->willReturn(1);
@@ -437,101 +443,69 @@ class AdyenInitPaymentsTest extends AbstractAdyenTestCase
 
         $this->transferFactory->method('create')->willReturn($this->transferMock);
 
+        $this->transactionPaymentClient->method('placeRequest')->willReturn([
+            $paymentsResponse,
+        ]);
+
+        // Capture setAdditionalInformation calls (PHPUnit 10 compatible)
+        $calls = [];
+        $paymentMock->expects($this->exactly(count($expectedAdditionalInformationCalls)))
+            ->method('setAdditionalInformation')
+            ->willReturnCallback(function (string $key, $value) use (&$calls) {
+                $calls[] = [$key, $value];
+                return null;
+            });
+
+        $this->paymentResponseHandler->expects($this->once())
+            ->method('formatPaymentResponse')
+            ->with(...$expectedFormatPaymentResponseArgs)
+            ->willReturn(['status' => $expectedStatus]);
+
+        $result = $this->adyenInitPayments->execute($this->stateData, 1);
+
+        $this->assertJson($result);
+        $this->assertStringContainsString($expectedStatus, $result);
+        $this->assertSame($expectedAdditionalInformationCalls, $calls);
+    }
+
+    public static function additionalInformationProvider(): array
+    {
         $action = ['type' => 'redirect', 'url' => 'https://example.test/redirect'];
         $additionalData = ['foo' => 'bar'];
         $details = ['payload' => 'abc'];
 
-        $this->transactionPaymentClient->method('placeRequest')->willReturn([
-            [
-                'resultCode' => 'Pending',
-                'pspReference' => 'PSP-123',
-                'action' => $action,
-                'additionalData' => $additionalData,
-                'details' => $details,
+        return [
+            'all fields present' => [
+                'paymentsResponse' => [
+                    'resultCode' => 'Authorised',
+                    'pspReference' => 'PSP-123',
+                    'action' => $action,
+                    'additionalData' => $additionalData,
+                    'details' => $details,
+                ],
+                'expectedAdditionalInformationCalls' => [
+                    ['resultCode', 'Authorised'],
+                    ['pspReference', 'PSP-123'],
+                    ['action', $action],
+                    ['additionalData', $additionalData],
+                    ['details', $details],
+                ],
+                'expectedFormatPaymentResponseArgs' => ['Authorised', $action],
+                'expectedStatus' => 'success',
             ],
-        ]);
 
-        $calls = [];
-        $paymentMock->expects($this->exactly(5))
-            ->method('setAdditionalInformation')
-            ->willReturnCallback(function (string $key, $value) use (&$calls) {
-                $calls[] = [$key, $value];
-                return null;
-            });
-
-        $this->paymentResponseHandler->expects($this->once())
-            ->method('formatPaymentResponse')
-            ->with('Pending', $action)
-            ->willReturn(['status' => 'success']);
-
-        $result = $this->adyenInitPayments->execute($this->stateData, 1);
-
-        $this->assertJson($result);
-        $this->assertStringContainsString('success', $result);
-        $this->assertSame([
-            ['resultCode', 'Pending'],
-            ['pspReference', 'PSP-123'],
-            ['action', $action],
-            ['additionalData', $additionalData],
-            ['details', $details],
-        ], $calls);
-    }
-
-    public function testExecuteSetsOnlyResultCodeWhenOptionalFieldsAreMissing(): void
-    {
-        $paymentMock = $this->createMock(\Magento\Quote\Model\Quote\Payment::class);
-
-        $this->quote->method('reserveOrderId')->willReturnSelf();
-        $this->cartRepository->method('get')->willReturn($this->quote);
-        $this->cartRepository->expects($this->exactly(2))->method('save')->with($this->quote);
-
-        $this->quote->method('getStoreId')->willReturn(1);
-        $this->quote->method('getReservedOrderId')->willReturn('order123');
-        $this->quote->method('getPayment')->willReturn($paymentMock);
-
-        $this->quote->method('__call')->willReturnMap([
-            ['getQuoteCurrencyCode', [], 'USD'],
-            ['getSubtotalWithDiscount', [], 99.0],
-        ]);
-
-        $this->returnUrlHelper->method('getStoreReturnUrl')->willReturn('https://example.test/adyen/return');
-        $this->shopperConversionId->method('getShopperConversionId')->willReturn(null);
-
-        $pmInstance = $this->createMock(MethodInterface::class);
-        $this->dataHelper->method('getMethodInstance')->with('adyen_paypal')->willReturn($pmInstance);
-        $this->paymentMethodsHelper->method('getRequiresLineItems')->with($pmInstance)->willReturn(false);
-        $this->lineItemsDataBuilder->method('getOpenInvoiceDataForQuote')->willReturn([]);
-
-        $this->platformInfo->method('buildRequestHeaders')->willReturn($this->headers);
-        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn(json_decode($this->stateData, true));
-        $this->adyenHelper->method('formatAmount')->with(99.0, 'USD')->willReturn(9900);
-        $this->configHelper->method('getMerchantAccount')->with(1)->willReturn('TestMerchant');
-        $this->userContext->method('getUserType')->willReturn(UserContextInterface::USER_TYPE_GUEST);
-
-        $this->transferFactory->method('create')->willReturn($this->transferMock);
-
-        $this->transactionPaymentClient->method('placeRequest')->willReturn([
-            ['resultCode' => 'Refused', 'action' => null],
-        ]);
-
-        $calls = [];
-        $paymentMock->expects($this->once())
-            ->method('setAdditionalInformation')
-            ->willReturnCallback(function (string $key, $value) use (&$calls) {
-                $calls[] = [$key, $value];
-                return null;
-            });
-
-        $this->paymentResponseHandler->expects($this->once())
-            ->method('formatPaymentResponse')
-            ->with('Refused', null)
-            ->willReturn(['status' => 'refused']);
-
-        $result = $this->adyenInitPayments->execute($this->stateData, 1);
-
-        $this->assertSame([['resultCode', 'Refused']], $calls);
-        $this->assertJson($result);
-        $this->assertStringContainsString('refused', $result);
+            'only resultCode present' => [
+                'paymentsResponse' => [
+                    'resultCode' => 'Refused',
+                    'action' => null,
+                ],
+                'expectedAdditionalInformationCalls' => [
+                    ['resultCode', 'Refused'],
+                ],
+                'expectedFormatPaymentResponseArgs' => ['Refused', null],
+                'expectedStatus' => 'refused',
+            ],
+        ];
     }
 
     public function testExecuteDoesNotSetAdditionalInformationWhenQuotePaymentIsNull(): void


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR aims to solve the Graphql issues for Paypal Express, where the Offers could not be completed because of failing details call. The `additionalInformation` wasn't saved for the Paypal Express init payments call and that resulted in not setting the quote to active again after completing the order in magento.