### PR TITLE
[ECP-9865-V2] Unable to Promote Paypal Express Offers to Payment

### DIFF
--- a/Model/AdyenInitPayments.php
+++ b/Model/AdyenInitPayments.php
@@ -169,18 +169,11 @@ class AdyenInitPayments implements AdyenInitPaymentsInterface
             $paymentsResponse = $this->returnFirstTransactionPaymentResponse($response);
             $quotePayment = $quote->getPayment();
             if ($quotePayment) {
-                $quotePayment->setAdditionalInformation('resultCode', $paymentsResponse['resultCode'] ?? null);
-                if (!empty($paymentsResponse['pspReference'])) {
-                    $quotePayment->setAdditionalInformation('pspReference', $paymentsResponse['pspReference']);
-                }
-                if (!empty($paymentsResponse['action'])) {
-                    $quotePayment->setAdditionalInformation('action', $paymentsResponse['action']);
-                }
-                if (!empty($paymentsResponse['additionalData'])) {
-                    $quotePayment->setAdditionalInformation('additionalData', $paymentsResponse['additionalData']);
-                }
-                if (!empty($paymentsResponse['details'])) {
-                    $quotePayment->setAdditionalInformation('details', $paymentsResponse['details']);
+                $keysToSet = ['resultCode', 'pspReference', 'action', 'additionalData', 'details'];
+                foreach ($keysToSet as $key) {
+                    if (!empty($paymentsResponse[$key])) {
+                        $quotePayment->setAdditionalInformation($key, $paymentsResponse[$key]);
+                    }
                 }
             }
 


### PR DESCRIPTION

## Summary
This PR aims to solve the Graphql issues for Paypal Express, where the Offers could not be completed because of failing details call. The additionalInformation wasn't saved for the Paypal Express init payments call and that resulted in not setting the quote to active again after completing the order in magento.
