### PR TITLE
[ECP-8388] Multiple calls to getCountries being made by express module

### DIFF
--- a/view/frontend/web/js/model/countries.js
+++ b/view/frontend/web/js/model/countries.js
@@ -14,13 +14,17 @@ define([
 
         initialize: function () {
             this._super();
-            if (!Object.keys(this.countries).length || !this.fetchingCountries) {
+
+            if (!Object.keys(this.countries()).length && !this.fetchingCountries) {
                 this.fetchingCountries = true;
+
                 getCountries()
                     .done(function (countries) {
                         const processedCountries = processCountries(countries);
 
                         this.setCountries(processedCountries);
+                    }.bind(this))
+                    .always(function () {
                         this.fetchingCountries = false;
                     }.bind(this));
             }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
On Express Module, multiple calls are made to the `rest/V1/directory/countries` API. This happens because the UI component’s initialize method triggers the API call multiple times during component re-initialization.

The root cause is the conditional check:

`if (!Object.keys(this.countries()).length || !this.fetchingCountries) {`

Using the OR (||) operator allows the condition to pass even when a request is already in progress, as long as the countries list is still empty. Since the component can be initialized multiple times before the async request completes, this results in duplicate API calls.
If we update the condition to use an AND (&&) operator:

`if (!Object.keys(this.countries()).length && !this.fetchingCountries) {`

This ensures that the API call is made only once, and only when:
- the countries list has not yet been populated, and
- no request is currently in progress.

Another improvement was made while working on it - The `fetchingCountries` flag is used to prevent multiple simultaneous API requests.
If the flag is only reset in `.done()`, it would remain true in error scenarios (e.g. network failure or API error).

Using `.always()` ensures that:
 - The flag is reset regardless of success or failure
 - The component does not get stuck in a fetching state


**Fixed issue**:  <!-- #-prefixed issue number -->
#26 