### PR TITLE
🐞 [V2] Throw a dedicated exception when express init fails

### DIFF
--- a/Exception/GraphQlExpressInitException.php
+++ b/Exception/GraphQlExpressInitException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *
+ * Adyen ExpressCheckout Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\ExpressCheckout\Exception;
+
+use GraphQL\Error\ClientAware;
+use GraphQL\Error\ProvidesExtensions;
+
+/**
+ * Exception for GraphQL to be thrown when express checkout fails
+ *
+ * @api
+ */
+class GraphQlExpressInitException extends ExpressInitException implements ClientAware, ProvidesExtensions
+{
+    public const EXCEPTION_CATEGORY = 'graphql-adyen-express';
+
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return static::EXCEPTION_CATEGORY;
+    }
+
+    public function getExtensions(): array
+    {
+        return [
+            'category' => $this->getCategory(),
+        ];
+    }
+}

--- a/Model/Resolver/ExpressInitResolver.php
+++ b/Model/Resolver/ExpressInitResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Model\Resolver;
 
 use Adyen\ExpressCheckout\Api\Data\ProductCartParamsInterfaceFactory;
+use Adyen\ExpressCheckout\Exception\GraphQlExpressInitException;
 use Adyen\ExpressCheckout\Model\ExpressInit;
 use Adyen\Payment\Logger\AdyenLogger;
 use Exception;
@@ -83,16 +84,30 @@ class ExpressInitResolver implements ResolverInterface
             }
 
             $result = function () use ($productCartParams, $quoteId, $adyenMaskedQuoteId, $provider) {
-                return $provider->execute($productCartParams, $quoteId, $adyenMaskedQuoteId);
+                try {
+                    return $provider->execute($productCartParams, $quoteId, $adyenMaskedQuoteId);
+                } catch (Exception $e) {
+                    $this->onError($e);
+                }
             };
 
             return $this->valueFactory->create($result);
         } catch (Exception $e) {
-            $errorMessage = "An error occurred while initiating the express quote";
-            $logMessage = sprintf("%s: %s", $errorMessage, $e->getMessage());
-            $this->adyenLogger->error($logMessage);
-
-            throw new LocalizedException(__($errorMessage));
+            $this->onError($e);
         }
+    }
+
+    /**
+     * @param Exception $exception
+     * @return void
+     * @throws GraphQlExpressInitException
+     */
+    protected function onError(Exception $exception): void
+    {
+        $errorMessage = "An error occurred while initiating the express quote";
+        $logMessage = sprintf("%s: %s", $errorMessage, $exception->getMessage());
+        $this->adyenLogger->error($logMessage);
+
+        throw new GraphQlExpressInitException(__($errorMessage), $exception);
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

> ℹ️ The PR goes to `main-2` because today I use the v2.x module, but we need to do the same fix on v3.x.

## Summary

  - Add a dedicated `GraphQlExpressInitException` (extends `ExpressInitException`, implements `ClientAware` + `ProvidesExtensions`) so express init failures are surfaced to the client under a clear
  `graphql-adyen-express` category, instead of being masked as a generic `LocalizedException` (or stripped to `"Internal server error"` by webonyx).
  - Move the `try/catch` inside the deferred closure passed to `ValueFactory::create()`. Previously, any exception thrown by `ExpressInit::execute()` was raised at GraphQL execution time — outside of the outer
  `try/catch` in `resolve()` — so it was never logged through `AdyenLogger` and the client only received an opaque internal error.
  - Factor error handling in a single `onError()` method to avoid duplicating the log + throw logic between the outer catch and the deferred closure catch.

  ## Why
  The previous implementation had two issues:
  1. The outer `try/catch` in `resolve()` could never catch errors from `ExpressInit::execute()`, because the actual execution is deferred by `\GraphQL\Deferred` (see `vendor/webonyx/graphql-php/src/Deferred.php`). The
  Deferred constructor wraps the executor in its own try/catch and rejects the promise, so the outer catch is effectively dead code for runtime errors.
  2. Throwing a plain `LocalizedException` from a GraphQL resolver produces a non-client-safe error: webonyx replaces the message with `"Internal server error"`, and no extension category is exposed for the front-end to
   discriminate this failure.

  ## Test plan
  - [ ] Trigger an express init request with a valid payload → response unchanged.
  - [ ] Trigger an express init request that causes `ExpressInit::execute()` to throw (e.g. invalid quote, downstream Adyen API failure) → response contains a GraphQL error with:
    - `message: "An error occurred while initiating the express quote"`
    - `extensions.category: "graphql-adyen-express"`
  - [ ] Confirm the failure is logged via `AdyenLogger` with the underlying exception message appended.
  - [ ] Trigger an input validation failure (missing/invalid `productCartParams`) → still returns a `GraphQlInputException` (unchanged).