### PR TITLE
[ECP-9934] Fix missing setMethod in OverrideOrderStateFromOrderCommand

### DIFF
--- a/Plugin/OverrideOrderStateFromOrderCommand.php
+++ b/Plugin/OverrideOrderStateFromOrderCommand.php
@@ -27,6 +27,8 @@ class OverrideOrderStateFromOrderCommand
                 return $proceed($payment, $amount, $order);
             }
 
+            $payment->setMethod(Button::PAYPAL_METHOD_NAME);
+
             $order->setState(Order::STATE_NEW);
             $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_NEW));
 

--- a/Test/Unit/Plugin/OverrideOrderStateFromOrderCommandTest.php
+++ b/Test/Unit/Plugin/OverrideOrderStateFromOrderCommandTest.php
@@ -28,7 +28,7 @@ class OverrideOrderStateFromOrderCommandTest extends AbstractAdyenTestCase
     {
         $this->plugin = new OverrideOrderStateFromOrderCommand();
         $this->payment = $this->getMockBuilder(OrderPaymentInterface::class)
-            ->onlyMethods(['getMethod'])
+            ->onlyMethods(['getMethod', 'setMethod'])
             ->addMethods(['getIsTransactionPending', 'getIsFraudDetected'])
             ->getMockForAbstractClass();
         $this->order = $this->getMockBuilder(Order::class)
@@ -57,6 +57,11 @@ class OverrideOrderStateFromOrderCommandTest extends AbstractAdyenTestCase
         $currencyMock = $this->createMock(Currency::class);
         $currencyMock->method('formatTxt')->with(self::AMOUNT)->willReturn('€10.00');
         $this->order->method('getBaseCurrency')->willReturn($currencyMock);
+
+        $this->payment->expects($this->once())
+            ->method('setMethod')
+            ->with(Button::PAYPAL_METHOD_NAME)
+            ->willReturnSelf();
 
         $this->order->expects($this->once())
             ->method('setState')


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes the missing setMethod in OverrideOrderStateFromOrderCommand to restore PayPal Express payment method assignment. Without it, orders stay as adyen_paypal_express, breaking webhook payment-method comparison (null passed to strcmp) and causing OFFER_CLOSED webhooks to fail.
