### PR TITLE
Fix Required field language missing for device channel browser

### DIFF
--- a/Plugin/Gateway/Request/BrowserInfoDataBuilder.php
+++ b/Plugin/Gateway/Request/BrowserInfoDataBuilder.php
@@ -33,13 +33,18 @@ class BrowserInfoDataBuilder
     }
 
     /**
-     * After build intercept and ensure language is set in browser info.
+     * After build intercept and back-fill browserInfo.language when the client
+     * did not supply one.
      *
      * The Adyen Web Components SDK collects browserInfo.language client-side;
      * when it doesn't (e.g. after the v6 SDK upgrade, or unsupported browsers),
      * Adyen refuses 3DS2 authorisations with "Required field language missing
      * for device channel browser". Back-filling from the store locale here
      * applies to every payment method, not just express wallets.
+     *
+     * A value already present is left untouched even if it differs from the
+     * store locale — it is the customer's real browser locale and feeds 3DS2
+     * device fingerprinting, so it must not be replaced.
      *
      * @param Subject $subject
      * @param array $result
@@ -52,10 +57,11 @@ class BrowserInfoDataBuilder
         array $buildSubject
     ): array {
         $languageSet = $result['body']['browserInfo']['language'] ?? null;
-        $currentLocale = $this->getCurrentStoreLanguageCode();
-        if ($languageSet === null ||
-            ($currentLocale !== null && $languageSet !== $currentLocale)) {
-            $result['body']['browserInfo']['language'] = $currentLocale;
+        if ($languageSet === null || $languageSet === '') {
+            $currentLocale = $this->getCurrentStoreLanguageCode();
+            if ($currentLocale !== null) {
+                $result['body']['browserInfo']['language'] = $currentLocale;
+            }
         }
         return $result;
     }

--- a/Plugin/Gateway/Request/BrowserInfoDataBuilder.php
+++ b/Plugin/Gateway/Request/BrowserInfoDataBuilder.php
@@ -14,41 +14,32 @@ declare(strict_types=1);
 namespace Adyen\ExpressCheckout\Plugin\Gateway\Request;
 
 use Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder as Subject;
-use Adyen\ExpressCheckout\Model\IsExpressMethodResolverInterface;
 use Magento\Framework\Locale\Resolver as LocaleResolver;
-use Magento\Payment\Gateway\Data\PaymentDataObject;
-use Magento\Payment\Gateway\Helper\SubjectReader;
-use Magento\Store\Api\Data\StoreInterface;
-use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\Store\Model\Store;
-use Psr\Log\LoggerInterface;
 
 class BrowserInfoDataBuilder
 {
-    /**
-     * @var IsExpressMethodResolverInterface
-     */
-    private $isExpressMethodResolver;
-
     /**
      * @var LocaleResolver
      */
     private $localeResolver;
 
     /**
-     * @param IsExpressMethodResolverInterface $isExpressMethodResolver
      * @param LocaleResolver $localeResolver
      */
     public function __construct(
-        IsExpressMethodResolverInterface $isExpressMethodResolver,
         LocaleResolver $localeResolver
     ) {
-        $this->isExpressMethodResolver = $isExpressMethodResolver;
         $this->localeResolver = $localeResolver;
     }
 
     /**
-     * After build intercept and ensure language is set in browser info if express
+     * After build intercept and ensure language is set in browser info.
+     *
+     * The Adyen Web Components SDK collects browserInfo.language client-side;
+     * when it doesn't (e.g. after the v6 SDK upgrade, or unsupported browsers),
+     * Adyen refuses 3DS2 authorisations with "Required field language missing
+     * for device channel browser". Back-filling from the store locale here
+     * applies to every payment method, not just express wallets.
      *
      * @param Subject $subject
      * @param array $result
@@ -60,22 +51,19 @@ class BrowserInfoDataBuilder
         array $result,
         array $buildSubject
     ): array {
-        /** @var PaymentDataObject $paymentDataObject */
-        $paymentDataObject = SubjectReader::readPayment($buildSubject);
-        $payment = $paymentDataObject->getPayment();
-        if ($this->isExpressMethodResolver->execute($payment)) {
-            $languageSet = $result['body']['browserInfo']['language'] ?? null;
-            $currentLocale = $this->getCurrentStoreLanguageCode($buildSubject);
-            if ($languageSet === null ||
-                ($currentLocale !== null && $languageSet !== $currentLocale)) {
-                $result['body']['browserInfo']['language'] = $currentLocale;
-            }
+        $languageSet = $result['body']['browserInfo']['language'] ?? null;
+        $currentLocale = $this->getCurrentStoreLanguageCode();
+        if ($languageSet === null ||
+            ($currentLocale !== null && $languageSet !== $currentLocale)) {
+            $result['body']['browserInfo']['language'] = $currentLocale;
         }
         return $result;
     }
 
     /**
-     * Return Current Stores language
+     * Return the current store locale as a BCP-47 language tag
+     * (e.g. "en-GB"), matching the format a browser's navigator.language
+     * would report.
      *
      * @return string|null
      */
@@ -83,8 +71,7 @@ class BrowserInfoDataBuilder
     {
         $currentLocale = $this->localeResolver->getLocale() ?: null;
         if ($currentLocale !== null) {
-            $languageCodeSplit = explode('_', $currentLocale);
-            $currentLocale = $languageCodeSplit[1] ?? $currentLocale;
+            $currentLocale = str_replace('_', '-', $currentLocale);
         }
         return $currentLocale;
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
The existing server-side fallback for browserInfo.language is currently implemented only for Express Checkout payment methods (Apple Pay, Google Pay, and PayPal Express) via the BrowserInfoDataBuilder plugin.

Standard card (adyen_cc) payments rely solely on the Adyen Web Components SDK to populate browserInfo.language from navigator.language. When this value is missing, the payment request is sent without the required browserInfo.language field, resulting in the Adyen validation error:

15_002 – Required field language missing for device channel browser

This PR extends the existing server-side fallback to standard card payments by populating browserInfo.language from the Magento store locale when it is absent, ensuring consistent behaviour across payment methods.
-->

## Tested scenarios
<!-- We were able to reproduce this issue on iOS devices when placing an order using a saved card. When we reviewed the corresponding requests in the Adyen Customer Area, we found that these transactions are failing with the following error:15_002 – Required field language missing for device channel browser-->


