### PR TITLE
[ECP-9966] Pass configured brands to Google Pay Express component

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -198,7 +198,9 @@ define([
                             }
                         }
                     },
-                    paymentMethodsResponse: getPaymentMethod('googlepay', this.isProductView),
+                    paymentMethodsResponse: {
+                        paymentMethods: googlePaymentMethod ? [googlePaymentMethod] : []
+                    },
                     onAdditionalDetails: this.handleOnAdditionalDetails.bind(this),
                     risk: {
                         enabled: false
@@ -306,6 +308,10 @@ define([
                     onError: () => cancelCart(this.isProductView),
                     ...googlePayStyles
                 };
+
+                if (Array.isArray(googlePaymentMethod.brands) && googlePaymentMethod.brands.length > 0) {
+                    configuration.brands = googlePaymentMethod.brands;
+                }
 
                 if (!isVirtual) {
                     configuration.callbackIntents = ['SHIPPING_ADDRESS', 'SHIPPING_OPTION'];


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
Google Pay Express offered card networks that are not enabled on the account (e.g. Discover), because the component config omitted `brands` and `paymentMethodsResponse` was passed an unresolved promise, so the SDK fell back to its default network list. Now the brands from /paymentMethods are passed to the component and the resolved payment method is passed as `paymentMethodsResponse`.
